### PR TITLE
fix: set journal_mode=DELETE for WASM SQLite compatibility

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @Ansvar-Systems/engineering

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,30 @@
+# Code of Conduct
+
+## Our Commitment
+
+We are committed to providing a welcoming and inspiring community for all.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment include:
+
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive criticism
+- Focusing on what is best for the community
+- Showing empathy towards other community members
+
+Examples of unacceptable behavior include:
+
+- Harassment, intimidation, or discrimination in any form
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Publishing others' private information without explicit permission
+
+## Enforcement
+
+Instances of unacceptable behavior may be reported by contacting the project team at hello@ansvar.ai.
+
+We will review and investigate all complaints and will respond in a way that we deem appropriate to the circumstances.
+
+---
+
+**This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.0.**

--- a/REGISTRY.md
+++ b/REGISTRY.md
@@ -1,0 +1,35 @@
+# Registry Metadata
+
+This file documents the registry information for Danish Law MCP.
+
+## npm
+
+**Package:** `@ansvar/danish-law-mcp`
+
+**Description:**
+Danish legislation via MCP — 62,764 laws, 620,940 provisions. Part of Ansvar Open Law (ansvar.eu/open-law)
+
+## Registry Fields
+
+| Field | Value |
+|-------|-------|
+| `name` | Danish Law MCP |
+| `author` | Ansvar Systems |
+| `author_url` | https://ansvar.eu |
+| `category` | legal / law / reference |
+| `tags` | law, legislation, denmark, danish, legal-research, compliance, mcp, open-law |
+| `license` | Apache-2.0 |
+| `homepage` | https://ansvar.eu/open-law |
+| `repository` | https://github.com/Ansvar-Systems/Denmark-law-mcp |
+| `endpoint` | https://danish-law-mcp.fly.dev/mcp |
+
+## Medium Description (Smithery/Glama/mcp.run)
+
+Query 62,764 Danish statutes — from the Databeskyttelsesloven and Straffeloven to the Persondataloven
+— directly from Claude, Cursor, or any MCP-compatible client. Full-text search across
+620,940 provisions with EU cross-references.
+
+Built by Ansvar Systems (ansvar.eu) — part of Ansvar Open Law, providing free structured
+access to legislation from 70+ jurisdictions worldwide.
+
+This is a research tool, not legal advice. Verify critical citations against official sources.

--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
   },
   "dependencies": {
     "@ansvar/mcp-sqlite": "^1.0.3",
-    "@modelcontextprotocol/sdk": "^1.25.3"
+    "@modelcontextprotocol/sdk": "^1.25.3",
+    "better-sqlite3": "^12.6.2"
   },
   "devDependencies": {
     "@types/jsdom": "^21.1.7",

--- a/scripts/build-db-paid.ts
+++ b/scripts/build-db-paid.ts
@@ -162,6 +162,7 @@ function buildPaidTier(): void {
   updateMeta();
 
   db.pragma('wal_checkpoint(TRUNCATE)');
+  db.pragma('journal_mode = DELETE');  // WASM SQLite compat: switch from WAL before closing
   db.exec('ANALYZE');
   db.close();
 

--- a/scripts/build-db.ts
+++ b/scripts/build-db.ts
@@ -1008,6 +1008,7 @@ function buildDatabase(): void {
   writeMeta();
 
   db.pragma('wal_checkpoint(TRUNCATE)');
+  db.pragma('journal_mode = DELETE');  // WASM SQLite compat: switch from WAL before closing
   db.exec('ANALYZE');
   db.close();
 

--- a/scripts/ingest-lagennu-cases.ts
+++ b/scripts/ingest-lagennu-cases.ts
@@ -601,6 +601,7 @@ async function ingestCaseLaw(limit?: number): Promise<void> {
     log('');
     log('Optimizing database...');
     db.pragma('wal_checkpoint(TRUNCATE)');
+    db.pragma('journal_mode = DELETE');  // WASM SQLite compat: switch from WAL before closing
     db.exec('ANALYZE');
 
   } finally {

--- a/scripts/ingest-lagennu-full-archive.ts
+++ b/scripts/ingest-lagennu-full-archive.ts
@@ -450,6 +450,7 @@ async function scrapeFullArchive(options: ScrapeOptions): Promise<void> {
       // Optimize database
       log('\nOptimizing database...');
       db.pragma('wal_checkpoint(TRUNCATE)');
+      db.pragma('journal_mode = DELETE');  // WASM SQLite compat: switch from WAL before closing
       db.exec('ANALYZE');
     }
 

--- a/scripts/sync-lagennu-cases.ts
+++ b/scripts/sync-lagennu-cases.ts
@@ -414,6 +414,7 @@ async function syncCaseLaw(options: SyncOptions): Promise<SyncReport> {
       log('');
       log('Optimizing database...');
       db.pragma('wal_checkpoint(TRUNCATE)');
+      db.pragma('journal_mode = DELETE');  // WASM SQLite compat: switch from WAL before closing
       db.exec('ANALYZE');
 
       const finalMetadata = getLastSyncMetadata(db);


### PR DESCRIPTION
## Summary
- Set `PRAGMA journal_mode = DELETE` after WAL checkpoint in all 5 build scripts
- Fixes `unable to open database file` error when `@ansvar/mcp-sqlite` (WASM) opens a WAL-mode database with `readonly: true`
- Added `better-sqlite3` as a dependency for the journal mode conversion step

## Context
The Danish-law-mcp uses `@ansvar/mcp-sqlite` which runs SQLite via WebAssembly. WASM SQLite cannot handle WAL journal mode databases when opened in readonly mode. The build scripts create the database in WAL mode (SQLite default for write transactions), but the runtime opens it readonly.

## Test plan
- [ ] Build database with `npm run build:db`
- [ ] Verify database journal mode is DELETE: `sqlite3 data/database.db "PRAGMA journal_mode"`
- [ ] Start server and confirm all 14 tools respond correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)