### PR TITLE
feat: add premium ingestion scripts for case law and preparatory works

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,8 @@
     "ingest:document": "tsx scripts/ingest-retsinformation.ts",
     "ingest:relevant": "tsx scripts/ingest-relevant-laws.ts",
     "ingest:auto-all": "node --import tsx scripts/auto-ingest-all-statutes.ts",
+    "ingest:domsdatabasen": "node --import tsx scripts/ingest-domsdatabasen.ts",
+    "ingest:folketinget": "node --import tsx scripts/ingest-folketinget.ts",
     "ingest:cases": "tsx scripts/ingest-lagennu-cases.ts",
     "ingest:cases:full-archive": "tsx scripts/ingest-lagennu-full-archive.ts",
     "sync:cases": "tsx scripts/sync-lagennu-cases.ts",
@@ -48,6 +50,7 @@
     "@modelcontextprotocol/sdk": "^1.25.3"
   },
   "devDependencies": {
+    "better-sqlite3": "npm:@ansvar/mcp-sqlite@^1.0.3",
     "@types/jsdom": "^21.1.7",
     "@types/node": "^22.15.29",
     "@vercel/node": "^5.6.3",

--- a/scripts/ingest-domsdatabasen.ts
+++ b/scripts/ingest-domsdatabasen.ts
@@ -1,0 +1,280 @@
+#!/usr/bin/env tsx
+/**
+ * Ingest Danish court decisions from Domsdatabasen (alexandrainst/domsdatabasen).
+ *
+ * Source:   HuggingFace Datasets Server REST API (JSON, no auth)
+ * Dataset:  alexandrainst/domsdatabasen — ~3,920 decisions, CC0 1.0
+ * Courts:   32 Danish courts (Højesteret, Østre/Vestre Landsret, byret, etc.)
+ *
+ * Populates: legal_documents (type='case_law'), case_law, case_law_full
+ *
+ * Usage:
+ *   npm run ingest:domsdatabasen                  # full ingestion
+ *   npm run ingest:domsdatabasen -- --limit 50    # test with 50 rows
+ *   npm run ingest:domsdatabasen -- --resume      # skip existing
+ *   npm run ingest:domsdatabasen -- --dry-run     # preview only
+ */
+
+import Database from '@ansvar/mcp-sqlite';
+import * as fs from 'fs';
+import * as path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const DB_PATH = path.resolve(__dirname, '../data/database.db');
+
+// ─────────────────────────────────────────────────────────────────────────────
+// HuggingFace Datasets Server API
+// ─────────────────────────────────────────────────────────────────────────────
+
+const DATASET = 'alexandrainst/domsdatabasen';
+const HF_ROWS_URL = 'https://datasets-server.huggingface.co/rows';
+const PAGE_SIZE = 100; // max allowed by HF API
+
+interface DomsdatabasenRow {
+  case_id: string;                     // e.g. "1"
+  Overskrift: string;                  // heading / summary
+  'Afgørelsesstatus': string;          // e.g. "Appelleret", "Ikke appelleret"
+  Faggruppe: string;                   // e.g. "Civilsag", "Straffesag"
+  Ret: string;                         // court, e.g. "Vestre Landsret"
+  'Rettens sagsnummer': string;        // case number, e.g. "BS-19416/2020-VLR"
+  Sagstype: string;                    // e.g. "Almindelig civil sag"
+  Instans: string;                     // e.g. "1. instans", "2. instans"
+  'Domsdatabasens sagsnummer': string; // e.g. "2/21"
+  Sagsemner: string;                   // semicolon-separated keywords
+  text: string;                        // full decision text
+  text_anonymized: string;             // anonymized version
+  text_len: number;
+  [key: string]: unknown;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Court normalization
+// ─────────────────────────────────────────────────────────────────────────────
+
+const COURT_MAP: Record<string, string> = {
+  'højesteret': 'Højesteret',
+  'østre landsret': 'Østre Landsret',
+  'vestre landsret': 'Vestre Landsret',
+  'sø- og handelsretten': 'Sø- og Handelsretten',
+};
+
+function normalizeCourt(raw: string): string {
+  const lower = raw.trim().toLowerCase();
+  return COURT_MAP[lower] ?? raw.trim();
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Date extraction from decision text
+// ─────────────────────────────────────────────────────────────────────────────
+
+const DANISH_MONTHS: Record<string, string> = {
+  januar: '01', februar: '02', marts: '03', april: '04',
+  maj: '05', juni: '06', juli: '07', august: '08',
+  september: '09', oktober: '10', november: '11', december: '12',
+};
+
+/**
+ * Extract decision date from the text body.
+ * Danish decisions typically start with "afsagt den 15. juni 2021" or similar.
+ */
+function extractDate(text: string): string {
+  // Match "afsagt den DD. MMMM YYYY" or "den DD. MMMM YYYY"
+  const match = text.match(/(?:afsagt|afsagt den|den)\s+(\d{1,2})\.\s+(\w+)\s+(\d{4})/i);
+  if (match) {
+    const [, day, monthStr, year] = match;
+    const month = DANISH_MONTHS[monthStr.toLowerCase()];
+    if (month) {
+      return `${year}-${month}-${day.padStart(2, '0')}`;
+    }
+  }
+  // Fallback: try to extract year from case number (e.g. BS-19416/2020-VLR → 2020)
+  return '';
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Fetch with retry
+// ─────────────────────────────────────────────────────────────────────────────
+
+async function fetchWithRetry(url: string, maxRetries = 3): Promise<Response> {
+  for (let attempt = 1; attempt <= maxRetries; attempt++) {
+    const res = await fetch(url);
+    if (res.ok) return res;
+    if (res.status === 429 || res.status >= 500) {
+      const wait = attempt * 5000;
+      console.log(`  HTTP ${res.status} — retry ${attempt}/${maxRetries} in ${wait / 1000}s...`);
+      await new Promise(r => setTimeout(r, wait));
+      continue;
+    }
+    throw new Error(`HTTP ${res.status}: ${res.statusText} — ${url}`);
+  }
+  throw new Error(`Failed after ${maxRetries} retries — ${url}`);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// CLI args
+// ─────────────────────────────────────────────────────────────────────────────
+
+const args = process.argv.slice(2);
+const DRY_RUN = args.includes('--dry-run');
+const RESUME = args.includes('--resume');
+const limitIdx = args.indexOf('--limit');
+const MAX_ROWS = limitIdx >= 0 ? parseInt(args[limitIdx + 1], 10) : Infinity;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Main
+// ─────────────────────────────────────────────────────────────────────────────
+
+async function main(): Promise<void> {
+  console.log('═══ Domsdatabasen Ingestion ═══');
+  console.log(`  Dataset:  ${DATASET}`);
+  console.log(`  Mode:     ${DRY_RUN ? 'DRY RUN' : 'LIVE'}`);
+  console.log(`  Resume:   ${RESUME}`);
+  console.log(`  Limit:    ${MAX_ROWS === Infinity ? 'none' : MAX_ROWS}`);
+  console.log();
+
+  // First, discover dataset info (total rows)
+  const infoUrl = `https://datasets-server.huggingface.co/info?dataset=${encodeURIComponent(DATASET)}`;
+  const infoRes = await fetchWithRetry(infoUrl);
+  const info = await infoRes.json() as {
+    dataset_info?: Record<string, { splits?: Record<string, { num_examples?: number }> }>;
+  };
+  const totalRows = info?.dataset_info?.default?.splits?.train?.num_examples ?? 0;
+  console.log(`  Total rows in dataset: ${totalRows.toLocaleString()}`);
+
+  if (DRY_RUN) {
+    console.log('\n  DRY RUN — would fetch and insert up to', Math.min(totalRows, MAX_ROWS), 'rows');
+    return;
+  }
+
+  // Open database
+  if (!fs.existsSync(DB_PATH)) {
+    console.error(`ERROR: No database at ${DB_PATH}. Run 'npm run build:db' first.`);
+    process.exit(1);
+  }
+
+  const db = new Database(DB_PATH);
+  db.pragma('foreign_keys = ON');
+  db.pragma('journal_mode = WAL');
+
+  // Check if case_law_full table exists (paid tier)
+  const hasCaseLawFull = !!db.prepare(
+    "SELECT name FROM sqlite_master WHERE type='table' AND name='case_law_full'"
+  ).get();
+
+  if (hasCaseLawFull) {
+    console.log('  Paid tier detected: will populate case_law_full');
+  }
+
+  // Existing IDs for --resume
+  const existingIds = new Set<string>();
+  if (RESUME) {
+    const rows = db.prepare("SELECT id FROM legal_documents WHERE id LIKE 'domsdatabasen:%'").all() as { id: string }[];
+    for (const r of rows) existingIds.add(r.id);
+    console.log(`  Resume: ${existingIds.size} existing entries will be skipped`);
+  }
+
+  // Prepared statements
+  const insertDoc = db.prepare(`
+    INSERT OR IGNORE INTO legal_documents (id, title, type, status, url)
+    VALUES (?, ?, 'case_law', 'in_force', ?)
+  `);
+
+  const insertCaseLaw = db.prepare(`
+    INSERT OR IGNORE INTO case_law (document_id, court, case_number, decision_date, summary, keywords)
+    VALUES (?, ?, ?, ?, ?, ?)
+  `);
+
+  const insertCaseLawFull = hasCaseLawFull
+    ? db.prepare(`
+        INSERT OR IGNORE INTO case_law_full (case_law_id, full_text, headnotes, dissenting_opinions)
+        VALUES (?, ?, NULL, NULL)
+      `)
+    : null;
+
+  // Stats
+  let inserted = 0;
+  let skipped = 0;
+  let failed = 0;
+  let offset = 0;
+
+  // Paginate through HuggingFace Datasets Server
+  while (offset < Math.min(totalRows, MAX_ROWS)) {
+    const length = Math.min(PAGE_SIZE, MAX_ROWS - offset);
+    const url = `${HF_ROWS_URL}?dataset=${encodeURIComponent(DATASET)}&config=default&split=train&offset=${offset}&length=${length}`;
+
+    let rows: DomsdatabasenRow[];
+    try {
+      const res = await fetchWithRetry(url);
+      const data = await res.json() as { rows?: { row: DomsdatabasenRow }[] };
+      rows = (data.rows ?? []).map(r => r.row);
+    } catch (err) {
+      console.error(`  Error fetching offset ${offset}:`, err);
+      failed += length;
+      offset += length;
+      continue;
+    }
+
+    if (rows.length === 0) break;
+
+    // Insert batch in a transaction
+    const insertBatch = db.transaction(() => {
+      for (const row of rows) {
+        const docId = `domsdatabasen:${row.case_id}`;
+
+        if (RESUME && existingIds.has(docId)) {
+          skipped++;
+          continue;
+        }
+
+        const court = normalizeCourt(row.Ret ?? 'Unknown');
+        const caseNumber = row['Rettens sagsnummer'] ?? '';
+        const fullText = row.text ?? '';
+        const date = extractDate(fullText);
+        const summary = row.Overskrift ?? '';
+        const keywords = row.Sagsemner ?? '';
+        const title = `${court} — ${caseNumber || row.case_id}${date ? ` (${date})` : ''}`;
+
+        try {
+          insertDoc.run(docId, title, `https://huggingface.co/datasets/${DATASET}`);
+          const result = insertCaseLaw.run(docId, court, caseNumber, date, summary, keywords);
+
+          if (insertCaseLawFull && result.changes > 0 && fullText) {
+            const caseLawId = db.prepare('SELECT id FROM case_law WHERE document_id = ?').get(docId) as { id: number } | undefined;
+            if (caseLawId) {
+              insertCaseLawFull.run(caseLawId.id, fullText);
+            }
+          }
+
+          inserted++;
+        } catch (err) {
+          // Likely duplicate
+          skipped++;
+        }
+      }
+    });
+
+    insertBatch();
+
+    offset += rows.length;
+    if (offset % 500 === 0 || offset >= Math.min(totalRows, MAX_ROWS)) {
+      console.log(`  [${offset}] inserted=${inserted} skipped=${skipped} failed=${failed}`);
+    }
+  }
+
+  // Finalize
+  db.pragma('wal_checkpoint(TRUNCATE)');
+  db.close();
+
+  console.log(`\n═══ Domsdatabasen Ingestion Complete ═══`);
+  console.log(`  Inserted: ${inserted}`);
+  console.log(`  Skipped:  ${skipped}`);
+  console.log(`  Failed:   ${failed}`);
+  console.log(`  Database: ${DB_PATH}`);
+}
+
+main().catch(err => {
+  console.error('Fatal error:', err);
+  process.exit(1);
+});

--- a/scripts/ingest-folketinget.ts
+++ b/scripts/ingest-folketinget.ts
@@ -1,0 +1,337 @@
+#!/usr/bin/env tsx
+/**
+ * Ingest Danish preparatory works (lovforslag) from Folketinget OData API.
+ *
+ * Source:   oda.ft.dk — Danish Parliament Open Data API (OData v3)
+ * Content:  ~5,200+ lovforslag (legislative proposals), public domain
+ *
+ * Populates: legal_documents (type='bill'), preparatory_works, preparatory_works_full
+ *
+ * Links lovforslag → statutes via lovnummer/lovnummerdato when enacted.
+ *
+ * Usage:
+ *   npm run ingest:folketinget                      # full ingestion
+ *   npm run ingest:folketinget -- --limit 50        # test with 50 rows
+ *   npm run ingest:folketinget -- --resume          # skip existing
+ *   npm run ingest:folketinget -- --dry-run         # preview only
+ *   npm run ingest:folketinget -- --enacted-only    # only enacted bills (statusid=11)
+ */
+
+import Database from '@ansvar/mcp-sqlite';
+import * as fs from 'fs';
+import * as path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const DB_PATH = path.resolve(__dirname, '../data/database.db');
+const CACHE_DIR = path.resolve(__dirname, '../data/source/folketinget');
+
+// ─────────────────────────────────────────────────────────────────────────────
+// OData API
+// ─────────────────────────────────────────────────────────────────────────────
+
+const ODA_BASE = 'https://oda.ft.dk/api';
+const PAGE_SIZE = 100; // OData max
+
+// Status IDs for lovforslag lifecycle
+const STATUS_MAP: Record<number, string> = {
+  25: 'Fremsat',                        // Introduced
+  28: '1. behandling',                  // 1st reading
+  32: '2. behandling / direkte til 3.', // 2nd reading
+  33: '2. behandling / udvalg',         // 2nd reading, committee
+  41: 'Vedtaget',                       // Passed (3rd reading)
+  11: 'Stadfæstet',                     // Royal assent (enacted)
+  3:  'Forkastet',                      // Rejected
+  37: 'Forkastet (3. behandling)',      // Rejected at 3rd reading
+  4:  'Tilbagetaget',                   // Withdrawn
+  13: 'Bortfaldet',                     // Lapsed
+  40: 'Delt',                           // Split into sub-bills
+};
+
+interface FolketingetSag {
+  id: number;
+  typeid: number;
+  statusid: number;
+  titel: string;
+  titelkort: string;
+  nummer: string;           // e.g. "L 120"
+  resume: string | null;    // summary/abstract
+  lovnummer: string | null; // law number when enacted
+  lovnummerdato: string | null;
+  afgørelsesdato: string | null;
+  opdateringsdato: string;
+  periodeid: number;
+  kategoriid: number | null;
+  fremsatundersagid: number | null;
+  deltundersagid: number | null;
+}
+
+interface EmneordSag {
+  Emneord?: { emneord: string };
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Fetch with retry
+// ─────────────────────────────────────────────────────────────────────────────
+
+async function fetchJson<T>(url: string, maxRetries = 3): Promise<T> {
+  for (let attempt = 1; attempt <= maxRetries; attempt++) {
+    const res = await fetch(url);
+    if (res.ok) return res.json() as T;
+    if (res.status === 429 || res.status >= 500) {
+      const wait = attempt * 3000;
+      console.log(`  HTTP ${res.status} — retry ${attempt}/${maxRetries} in ${wait / 1000}s...`);
+      await new Promise(r => setTimeout(r, wait));
+      continue;
+    }
+    throw new Error(`HTTP ${res.status}: ${res.statusText} — ${url}`);
+  }
+  throw new Error(`Failed after ${maxRetries} retries — ${url}`);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// CLI args
+// ─────────────────────────────────────────────────────────────────────────────
+
+const args = process.argv.slice(2);
+const DRY_RUN = args.includes('--dry-run');
+const RESUME = args.includes('--resume');
+const ENACTED_ONLY = args.includes('--enacted-only');
+const limitIdx = args.indexOf('--limit');
+const MAX_ROWS = limitIdx >= 0 ? parseInt(args[limitIdx + 1], 10) : Infinity;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Try to find a matching statute in the DB by law number and year.
+ * Danish statutes are keyed as "{year}_{number}" in the legal_documents table.
+ */
+function findStatuteId(db: InstanceType<typeof Database>, lovnummer: string, lovnummerdato: string): string | null {
+  const year = lovnummerdato.substring(0, 4);
+
+  // Danish statute IDs use "{year}:{number}" format (e.g., "2024:306")
+  const colonId = `${year}:${lovnummer}`;
+  const colonMatch = db.prepare("SELECT id FROM legal_documents WHERE id = ? AND type != 'bill'").get(colonId) as { id: string } | undefined;
+  if (colonMatch) return colonMatch.id;
+
+  // Fallback: search by title
+  const titleMatch = db.prepare(
+    "SELECT id FROM legal_documents WHERE title LIKE ? AND type != 'bill' LIMIT 1"
+  ).get(`%nr. ${lovnummer}%`) as { id: string } | undefined;
+  if (titleMatch) return titleMatch.id;
+
+  return null;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Main
+// ─────────────────────────────────────────────────────────────────────────────
+
+async function main(): Promise<void> {
+  console.log('═══ Folketinget Lovforslag Ingestion ═══');
+  console.log(`  Source:   ${ODA_BASE}`);
+  console.log(`  Mode:     ${DRY_RUN ? 'DRY RUN' : 'LIVE'}`);
+  console.log(`  Resume:   ${RESUME}`);
+  console.log(`  Enacted:  ${ENACTED_ONLY ? 'only' : 'all'}`);
+  console.log(`  Limit:    ${MAX_ROWS === Infinity ? 'none' : MAX_ROWS}`);
+  console.log();
+
+  // Get total count
+  const filter = ENACTED_ONLY
+    ? "typeid eq 3 and statusid eq 11"
+    : "typeid eq 3";
+  const countUrl = `${ODA_BASE}/Sag?$filter=${encodeURIComponent(filter)}&$top=0&$inlinecount=allpages`;
+  const countData = await fetchJson<{ 'odata.count': string }>(countUrl);
+  const totalCount = parseInt(countData['odata.count'], 10);
+  console.log(`  Total lovforslag: ${totalCount.toLocaleString()}`);
+
+  if (DRY_RUN) {
+    console.log('\n  DRY RUN — would fetch and insert up to', Math.min(totalCount, MAX_ROWS), 'lovforslag');
+    return;
+  }
+
+  // Open database
+  if (!fs.existsSync(DB_PATH)) {
+    console.error(`ERROR: No database at ${DB_PATH}. Run 'npm run build:db' first.`);
+    process.exit(1);
+  }
+
+  const db = new Database(DB_PATH);
+  db.pragma('foreign_keys = ON');
+  db.pragma('journal_mode = WAL');
+
+  // Check if preparatory_works_full table exists (paid tier)
+  const hasPrepFull = !!db.prepare(
+    "SELECT name FROM sqlite_master WHERE type='table' AND name='preparatory_works_full'"
+  ).get();
+
+  if (hasPrepFull) {
+    console.log('  Paid tier detected: will populate preparatory_works_full');
+  }
+
+  // Ensure cache dir exists
+  fs.mkdirSync(CACHE_DIR, { recursive: true });
+
+  // Existing IDs for --resume
+  const existingIds = new Set<string>();
+  if (RESUME) {
+    const rows = db.prepare("SELECT id FROM legal_documents WHERE id LIKE 'ft-lovforslag:%'").all() as { id: string }[];
+    for (const r of rows) existingIds.add(r.id);
+    console.log(`  Resume: ${existingIds.size} existing entries will be skipped`);
+  }
+
+  // Prepared statements
+  const insertDoc = db.prepare(`
+    INSERT OR IGNORE INTO legal_documents (id, title, type, status, issued_date, url)
+    VALUES (?, ?, 'bill', ?, ?, ?)
+  `);
+
+  const insertPrepWork = db.prepare(`
+    INSERT OR IGNORE INTO preparatory_works (statute_id, prep_document_id, title, summary)
+    VALUES (?, ?, ?, ?)
+  `);
+
+  const insertPrepFull = hasPrepFull
+    ? db.prepare(`
+        INSERT OR IGNORE INTO preparatory_works_full (prep_work_id, full_text, section_summaries)
+        VALUES (?, ?, NULL)
+      `)
+    : null;
+
+  // Stats
+  let inserted = 0;
+  let linked = 0;
+  let skipped = 0;
+  let failed = 0;
+  let processed = 0;
+
+  // Paginate through OData API
+  let skip = 0;
+  while (processed < Math.min(totalCount, MAX_ROWS)) {
+    const top = Math.min(PAGE_SIZE, MAX_ROWS - processed);
+    const url = `${ODA_BASE}/Sag?$filter=${encodeURIComponent(filter)}&$orderby=id asc&$top=${top}&$skip=${skip}`;
+
+    let sager: FolketingetSag[];
+    try {
+      const data = await fetchJson<{ value: FolketingetSag[] }>(url);
+      sager = data.value ?? [];
+    } catch (err) {
+      console.error(`  Error fetching skip=${skip}:`, err);
+      failed += top;
+      skip += top;
+      processed += top;
+      continue;
+    }
+
+    if (sager.length === 0) break;
+
+    // Process each lovforslag
+    for (const sag of sager) {
+      if (processed >= MAX_ROWS) break;
+      processed++;
+
+      const docId = `ft-lovforslag:${sag.id}`;
+      if (RESUME && existingIds.has(docId)) {
+        skipped++;
+        continue;
+      }
+
+      const statusText = STATUS_MAP[sag.statusid] ?? `status-${sag.statusid}`;
+      const isEnacted = sag.statusid === 11;
+      const status = isEnacted ? 'in_force' : 'amended';
+      const title = sag.titel || sag.titelkort || `Lovforslag ${sag.nummer}`;
+      const summary = sag.resume ?? '';
+
+      // Determine the date — prefer afgørelsesdato for enacted, else opdateringsdato
+      const issuedDate = sag.afgørelsesdato
+        ? sag.afgørelsesdato.substring(0, 10)
+        : sag.opdateringsdato?.substring(0, 10) ?? '';
+
+      const ftUrl = `https://www.ft.dk/samling/lovforslag/${sag.nummer?.replace(/\s+/g, '').toLowerCase()}`;
+
+      // Fetch keywords
+      let keywords = '';
+      try {
+        const emneUrl = `${ODA_BASE}/EmneordSag?$filter=sagid eq ${sag.id}&$expand=Emneord`;
+        const emneData = await fetchJson<{ value: EmneordSag[] }>(emneUrl);
+        keywords = (emneData.value ?? [])
+          .map(e => e.Emneord?.emneord)
+          .filter(Boolean)
+          .join('; ');
+      } catch {
+        // Keywords are optional; skip on error
+      }
+
+      // Insert into DB
+      const insertOne = db.transaction(() => {
+        insertDoc.run(docId, title, status, issuedDate, ftUrl);
+
+        // Try to link to a statute if enacted
+        let statuteId: string | null = null;
+        if (isEnacted && sag.lovnummer && sag.lovnummerdato) {
+          statuteId = findStatuteId(db, sag.lovnummer, sag.lovnummerdato.substring(0, 10));
+        }
+
+        if (statuteId) {
+          const fullSummary = [
+            `${sag.nummer} — ${statusText}`,
+            summary ? `\n\n${summary}` : '',
+            keywords ? `\n\nEmneord: ${keywords}` : '',
+            sag.lovnummer ? `\n\nLov nr. ${sag.lovnummer} af ${sag.lovnummerdato?.substring(0, 10)}` : '',
+          ].join('');
+
+          insertPrepWork.run(statuteId, docId, title, fullSummary);
+
+          // Populate full text in paid tier
+          if (insertPrepFull && summary) {
+            const prepRow = db.prepare(
+              'SELECT id FROM preparatory_works WHERE prep_document_id = ?'
+            ).get(docId) as { id: number } | undefined;
+            if (prepRow) {
+              insertPrepFull.run(prepRow.id, fullSummary);
+            }
+          }
+
+          linked++;
+        }
+      });
+
+      try {
+        insertOne();
+        inserted++;
+      } catch (err) {
+        skipped++;
+      }
+
+      // Pace requests (keywords fetch adds 1 req per lovforslag)
+      if (processed % 100 === 0) {
+        await new Promise(r => setTimeout(r, 200));
+      }
+    }
+
+    skip += sager.length;
+
+    if (processed % 500 === 0 || processed >= Math.min(totalCount, MAX_ROWS)) {
+      console.log(`  [${processed}] inserted=${inserted} linked=${linked} skipped=${skipped} failed=${failed}`);
+    }
+  }
+
+  // Finalize
+  db.pragma('wal_checkpoint(TRUNCATE)');
+  db.close();
+
+  console.log(`\n═══ Folketinget Ingestion Complete ═══`);
+  console.log(`  Inserted:      ${inserted}`);
+  console.log(`  Linked to law: ${linked}`);
+  console.log(`  Skipped:       ${skipped}`);
+  console.log(`  Failed:        ${failed}`);
+  console.log(`  Database:      ${DB_PATH}`);
+}
+
+main().catch(err => {
+  console.error('Fatal error:', err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- Adds `scripts/ingest-domsdatabasen.ts` for Danish case law ingestion from HuggingFace
- Adds `scripts/ingest-folketinget.ts` for preparatory works from oda.ft.dk
- Updates `package.json` with script entries and better-sqlite3 alias

## Test plan
- [ ] Run `npx tsx scripts/ingest-domsdatabasen.ts --dry-run` to verify HuggingFace connectivity
- [ ] Run `npx tsx scripts/ingest-folketinget.ts --dry-run` to verify Folketinget API access
- [ ] Verify `npm run ingest:domsdatabasen` and `npm run ingest:folketinget` script aliases work

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>