### PR TITLE
docs: add golden-standard README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,19 @@
-# Swedish Law MCP Server
+# Danish Law MCP Server
 
-**The Riksdagen alternative for the AI age.**
+**The Retsinformation alternative for the AI age.**
 
-[![npm version](https://badge.fury.io/js/@ansvar%2Fswedish-law-mcp.svg)](https://www.npmjs.com/package/@ansvar/swedish-law-mcp)
+[![npm version](https://badge.fury.io/js/@ansvar%2Fdanish-law-mcp.svg)](https://www.npmjs.com/package/@ansvar/danish-law-mcp)
 [![MCP Registry](https://img.shields.io/badge/MCP-Registry-blue)](https://registry.modelcontextprotocol.io)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
-[![GitHub stars](https://img.shields.io/github/stars/Ansvar-Systems/swedish-law-mcp?style=social)](https://github.com/Ansvar-Systems/swedish-law-mcp)
-[![CI](https://github.com/Ansvar-Systems/swedish-law-mcp/actions/workflows/ci.yml/badge.svg)](https://github.com/Ansvar-Systems/swedish-law-mcp/actions/workflows/ci.yml)
-[![Daily Data Check](https://github.com/Ansvar-Systems/swedish-law-mcp/actions/workflows/check-updates.yml/badge.svg)](https://github.com/Ansvar-Systems/swedish-law-mcp/actions/workflows/check-updates.yml)
+[![GitHub stars](https://img.shields.io/github/stars/Ansvar-Systems/Denmark-law-mcp?style=social)](https://github.com/Ansvar-Systems/Denmark-law-mcp)
+[![CI](https://github.com/Ansvar-Systems/Denmark-law-mcp/actions/workflows/ci.yml/badge.svg)](https://github.com/Ansvar-Systems/Denmark-law-mcp/actions/workflows/ci.yml)
+[![Daily Data Check](https://github.com/Ansvar-Systems/Denmark-law-mcp/actions/workflows/check-updates.yml/badge.svg)](https://github.com/Ansvar-Systems/Denmark-law-mcp/actions/workflows/check-updates.yml)
 [![Database](https://img.shields.io/badge/database-pre--built-green)](docs/EU_INTEGRATION_GUIDE.md)
-[![Provisions](https://img.shields.io/badge/provisions-31%2C198-blue)](docs/EU_INTEGRATION_GUIDE.md)
+[![Provisions](https://img.shields.io/badge/provisions-620%2C940-blue)](docs/EU_INTEGRATION_GUIDE.md)
 
-Query **717 Swedish statutes** -- from Dataskyddslagen and Brottsbalken to Aktiebolagslagen, Miljöbalken, and more -- directly from Claude, Cursor, or any MCP-compatible client.
+Query **62,764 Danish laws** -- from Databeskyttelsesloven and Straffeloven to Selskabsloven, Forvaltningsloven, and more -- directly from Claude, Cursor, or any MCP-compatible client.
 
-If you're building legal tech, compliance tools, or doing Swedish legal research, this is your verified reference database.
+If you're building legal tech, compliance tools, or doing Danish legal research, this is your verified reference database.
 
 Built by [Ansvar Systems](https://ansvar.eu) -- Stockholm, Sweden
 
@@ -21,15 +21,16 @@ Built by [Ansvar Systems](https://ansvar.eu) -- Stockholm, Sweden
 
 ## Why This Exists
 
-Swedish legal research is scattered across Riksdagen, SFS publications, lagen.nu, and EUR-Lex. Whether you're:
+Danish legal research means navigating retsinformation.dk, cross-referencing between lovbekendtgørelser (consolidated laws), forslag (bills), betænkninger (committee reports), and EUR-Lex. Whether you're:
+
 - A **lawyer** validating citations in a brief or contract
-- A **compliance officer** checking if a statute is still in force
-- A **legal tech developer** building tools on Swedish law
-- A **researcher** tracing legislative history from proposition to statute
+- A **compliance officer** checking Databeskyttelsesloven obligations or GDPR alignment
+- A **legal tech developer** building tools on Danish law
+- A **researcher** tracing legislative history from lovforslag to enacted statute
 
-...you shouldn't need 47 browser tabs and manual PDF cross-referencing. Ask Claude. Get the exact provision. With context.
+...you shouldn't need dozens of browser tabs and manual PDF cross-referencing. Ask Claude. Get the exact provision. With context.
 
-This MCP server makes Swedish law **searchable, cross-referenceable, and AI-readable**.
+This MCP server makes Danish law **searchable, cross-referenceable, and AI-readable**.
 
 ---
 
@@ -37,38 +38,40 @@ This MCP server makes Swedish law **searchable, cross-referenceable, and AI-read
 
 ### Use Remotely (No Install Needed)
 
-> Connect directly to the hosted version — zero dependencies, nothing to install.
+> Connect directly to the hosted version -- zero dependencies, nothing to install.
 
-**Endpoint:** `https://swedish-law-mcp.vercel.app/mcp`
+**Endpoint:** `https://danish-law-mcp.fly.dev/mcp`
+
+> **Note:** This server is hosted on Fly.io rather than Vercel because the database (1.6 GB) exceeds Vercel's 50 MB deployment limit. The endpoint is otherwise identical in behaviour to other Ansvar Law MCP servers.
 
 | Client | How to Connect |
 |--------|---------------|
 | **Claude.ai** | Settings > Connectors > Add Integration > paste URL |
-| **Claude Code** | `claude mcp add swedish-law --transport http https://swedish-law-mcp.vercel.app/mcp` |
+| **Claude Code** | `claude mcp add danish-law --transport http https://danish-law-mcp.fly.dev/mcp` |
 | **Claude Desktop** | Add to config (see below) |
 | **GitHub Copilot** | Add to VS Code settings (see below) |
 
-**Claude Desktop** — add to `claude_desktop_config.json`:
+**Claude Desktop** -- add to `claude_desktop_config.json`:
 
 ```json
 {
   "mcpServers": {
-    "swedish-law": {
+    "danish-law": {
       "type": "url",
-      "url": "https://swedish-law-mcp.vercel.app/mcp"
+      "url": "https://danish-law-mcp.fly.dev/mcp"
     }
   }
 }
 ```
 
-**GitHub Copilot** — add to VS Code `settings.json`:
+**GitHub Copilot** -- add to VS Code `settings.json`:
 
 ```json
 {
   "github.copilot.chat.mcp.servers": {
-    "swedish-law": {
+    "danish-law": {
       "type": "http",
-      "url": "https://swedish-law-mcp.vercel.app/mcp"
+      "url": "https://danish-law-mcp.fly.dev/mcp"
     }
   }
 }
@@ -77,10 +80,10 @@ This MCP server makes Swedish law **searchable, cross-referenceable, and AI-read
 ### Use Locally (npm)
 
 ```bash
-npx @ansvar/swedish-law-mcp
+npx @ansvar/danish-law-mcp
 ```
 
-**Claude Desktop** — add to `claude_desktop_config.json`:
+**Claude Desktop** -- add to `claude_desktop_config.json`:
 
 **macOS:** `~/Library/Application Support/Claude/claude_desktop_config.json`
 **Windows:** `%APPDATA%\Claude\claude_desktop_config.json`
@@ -88,9 +91,9 @@ npx @ansvar/swedish-law-mcp
 ```json
 {
   "mcpServers": {
-    "swedish-law": {
+    "danish-law": {
       "command": "npx",
-      "args": ["-y", "@ansvar/swedish-law-mcp"]
+      "args": ["-y", "@ansvar/danish-law-mcp"]
     }
   }
 }
@@ -101,9 +104,9 @@ npx @ansvar/swedish-law-mcp
 ```json
 {
   "mcp.servers": {
-    "swedish-law": {
+    "danish-law": {
       "command": "npx",
-      "args": ["-y", "@ansvar/swedish-law-mcp"]
+      "args": ["-y", "@ansvar/danish-law-mcp"]
     }
   }
 }
@@ -111,17 +114,16 @@ npx @ansvar/swedish-law-mcp
 
 ## Example Queries
 
-Once connected, just ask naturally:
+Once connected, just ask naturally -- in Danish or English:
 
-- *"What does Dataskyddslagen 3 kap. 5 § say about consent?"*
-- *"Is PUL (1998:204) still in force?"*
-- *"Find provisions about personuppgifter in Swedish law"*
-- *"What EU directives does DSL implement?"*
-- *"Which Swedish laws implement the GDPR?"*
-- *"Get the preparatory works for Dataskyddslagen"*
-- *"Compare incident reporting requirements across NIS2 Swedish implementations"*
-- *"Validate the citation NJA 2020 s. 45"*
-- *"Find Labour Court cases about discrimination from 2020-2023"*
+- *"Hvad siger Databeskyttelsesloven § 5 om behandling af personoplysninger?"*
+- *"Er Straffelovens § 263 om hacking stadig i kraft?"*
+- *"Find bestemmelser om offentlighedsprincippet"*
+- *"Hvad siger konkurrenceretten om misbrug af dominerende stilling?"*
+- *"Valider citatet 'Straffelovens § 263'"*
+- *"Opbyg en juridisk argumentation om GDPR-forpligtelser for virksomheder"*
+- *"Which Danish laws implement the GDPR?"*
+- *"What does Forvaltningsloven say about administrative procedures?"*
 
 ---
 
@@ -129,15 +131,14 @@ Once connected, just ask naturally:
 
 | Category | Count | Details |
 |----------|-------|---------|
-| **Statutes** | 717 laws | Comprehensive Swedish legislation |
-| **Provisions** | 31,198 sections | Full-text searchable with FTS5 |
-| **Preparatory Works** | 3,625 documents | Propositions (Prop.) and SOUs |
-| **EU Cross-References** | 668 references | 228 EU directives and regulations |
-| **Legal Definitions** | 615 terms | Extracted from statute text |
-| **Database Size** | ~70 MB | Optimized SQLite, portable |
-| **Daily Updates** | Automated | Freshness checks against Riksdagen |
+| **Laws** | 62,764 laws | Complete corpus from retsinformation.dk |
+| **Provisions** | 620,940 sections | Full-text searchable with FTS5 |
+| **Premium: Case Law** | 3,918 rulings | Højesteret, Landsretter decisions |
+| **Premium: Preparatory Works** | 4,412 documents | Lovforslag, betænkninger |
+| **Database Size** | 1.6 GB | Optimized SQLite, hosted on Fly.io |
+| **Daily Updates** | Automated | Freshness checks against retsinformation.dk |
 
-**Verified data only** -- every citation is validated against official sources (Riksdagen, lagen.nu, EUR-Lex). Zero LLM-generated content.
+**Verified data only** -- every citation is validated against official sources (retsinformation.dk). Zero LLM-generated content.
 
 ---
 
@@ -146,37 +147,37 @@ Once connected, just ask naturally:
 ### Why This Works
 
 **Verbatim Source Text (No LLM Processing):**
-- All statute text is ingested from Riksdagen/SFS official sources
+- All statute text is ingested from retsinformation.dk (Danish Ministry of Justice)
 - Provisions are returned **unchanged** from SQLite FTS5 database rows
-- Zero LLM summarization or paraphrasing -- the database contains regulation text, not AI interpretations
+- Zero LLM summarization or paraphrasing -- the database contains statute text, not AI interpretations
 
 **Smart Context Management:**
 - Search returns ranked provisions with BM25 scoring (safe for context)
-- Provision retrieval gives exact text by SFS number + chapter/section
+- Provision retrieval gives exact text by law identifier + paragraph/section
 - Cross-references help navigate without loading everything at once
 
 **Technical Architecture:**
 ```
-Riksdagen API → Parse → SQLite → FTS5 snippet() → MCP response
-                  ↑                      ↑
-           Provision parser       Verbatim database query
+retsinformation.dk API --> Parse --> SQLite --> FTS5 snippet() --> MCP response
+                            ^                        ^
+                     Provision parser         Verbatim database query
 ```
 
 ### Traditional Research vs. This MCP
 
 | Traditional Approach | This MCP Server |
 |---------------------|-----------------|
-| Search Riksdagen by SFS number | Search by plain Swedish: *"personuppgifter samtycke"* |
-| Navigate multi-chapter statutes manually | Get the exact provision with context |
+| Search retsinformation.dk by document number | Search by plain Danish: *"personoplysninger samtykke"* |
+| Navigate multi-paragraph statutes manually | Get the exact provision with context |
 | Manual cross-referencing between laws | `build_legal_stance` aggregates across sources |
-| "Is this statute still in force?" → check manually | `check_currency` tool → answer in seconds |
+| "Er denne lov stadig i kraft?" → check manually | `check_currency` tool → answer in seconds |
 | Find EU basis → dig through EUR-Lex | `get_eu_basis` → linked EU directives instantly |
-| Check 5+ sites for updates | Daily automated freshness checks |
+| Check multiple sites for amendments | Daily automated freshness checks |
 | No API, no integration | MCP protocol → AI-native |
 
-**Traditional:** Search Riksdagen → Download SFS PDF → Ctrl+F → Cross-reference with proposition → Check EUR-Lex for EU basis → Repeat
+**Traditional:** Search retsinformation.dk → Download PDF → Ctrl+F → Cross-reference with betænkning → Check EUR-Lex for EU basis → Repeat
 
-**This MCP:** *"What EU law is the basis for DSL 3 kap. 5 § about consent?"* → Done.
+**This MCP:** *"Hvad er EU-retsgrundlaget for Databeskyttelsesloven § 5 om samtykke?"* → Done.
 
 ---
 
@@ -186,47 +187,40 @@ Riksdagen API → Parse → SQLite → FTS5 snippet() → MCP response
 
 | Tool | Description |
 |------|-------------|
-| `search_legislation` | FTS5 search on 31,198 provisions with BM25 ranking |
-| `get_provision` | Retrieve specific provision by SFS + chapter/section |
-| `search_case_law` | FTS5 search on case law with court/date filters |
-| `get_preparatory_works` | Get linked propositions and SOUs for a statute |
-| `validate_citation` | Validate citation against database (zero-hallucination check) |
-| `build_legal_stance` | Aggregate citations from statutes, case law, prep works |
-| `format_citation` | Format citations per Swedish conventions (full/short/pinpoint) |
-| `check_currency` | Check if statute is in force, amended, or repealed |
+| `search_legislation` | FTS5 search on 620,940 provisions with BM25 ranking. Supports quoted phrases, boolean operators, prefix wildcards |
+| `get_provision` | Retrieve specific provision by law identifier + paragraph/section (e.g., "Straffeloven" + "263") |
+| `check_currency` | Check if a law is in force, amended, or repealed |
+| `validate_citation` | Validate citation against database -- zero-hallucination check. Supports "Straffelovens § 263", "Databeskyttelsesloven § 5" |
+| `build_legal_stance` | Aggregate citations from multiple laws for a legal topic |
+| `format_citation` | Format citations per Danish conventions (full/short/pinpoint) |
+| `list_sources` | List all available laws with metadata, coverage scope, and data provenance |
+| `about` | Server info, capabilities, dataset statistics, and coverage summary |
 
 ### EU Law Integration Tools (5)
 
 | Tool | Description |
 |------|-------------|
-| `get_eu_basis` | Get EU directives/regulations for Swedish statute |
-| `get_swedish_implementations` | Find Swedish laws implementing EU act |
-| `search_eu_implementations` | Search EU documents with Swedish implementation counts |
-| `get_provision_eu_basis` | Get EU law references for specific provision |
-| `validate_eu_compliance` | Check implementation status (future, requires EU MCP) |
+| `get_eu_basis` | Get EU directives/regulations that a Danish statute transposes (e.g., Databeskyttelsesloven → GDPR) |
+| `get_danish_implementations` | Find Danish laws implementing a specific EU act |
+| `search_eu_implementations` | Search EU documents with Danish implementation counts |
+| `get_provision_eu_basis` | Get EU law references for a specific provision |
+| `validate_eu_compliance` | Check transposition status of Danish statutes against EU directives |
 
 ---
 
 ## EU Law Integration
 
-**668 cross-references** linking 49 Swedish statutes to EU law, with bi-directional lookup.
+Denmark is a full EU member state. Danish law directly transposes EU directives into national legislation:
 
-| Metric | Value |
-|--------|-------|
-| **EU References** | 668 cross-references |
-| **EU Documents** | 228 unique directives and regulations |
-| **Swedish Statutes with EU Refs** | 49 (68% of database) |
-| **Directives** | 89 |
-| **Regulations** | 139 |
-| **EUR-Lex Integration** | Automated metadata fetching |
+| Danish Law | EU Basis |
+|-----------|----------|
+| **Databeskyttelsesloven** | GDPR (Regulation 2016/679) |
+| **Implementeret e-Privacy** | ePrivacy Directive (2002/58/EC) |
+| **Konkurrenceretten** | EU Treaty Articles 101-102 (TFEU) |
 
-### Most Referenced EU Acts
+The EU integration tools support bi-directional lookup: find which EU act a Danish statute transposes, or find all Danish laws implementing a given EU regulation.
 
-1. **eIDAS Regulation** (910/2014) - 20 references
-2. **E-Signatures Directive** (1999/93) - 15 references
-3. **GDPR** (2016/679) - 15 references
-4. **Data Protection Directive** (1995/46) - 14 references
-5. **Market Surveillance Regulation** (2019/1020) - 14 references
+> **Denmark and EU opt-outs:** Denmark maintains opt-outs from certain EU policy areas (including Justice and Home Affairs, under Protocol 22 to the Maastricht Treaty). However, data protection law (GDPR), commercial law, and competition law are all fully aligned with EU frameworks. The EU tools in this MCP reflect full transposition coverage for these areas.
 
 See [EU_INTEGRATION_GUIDE.md](docs/EU_INTEGRATION_GUIDE.md) for detailed documentation and [EU_USAGE_EXAMPLES.md](docs/EU_USAGE_EXAMPLES.md) for practical examples.
 
@@ -234,26 +228,55 @@ See [EU_INTEGRATION_GUIDE.md](docs/EU_INTEGRATION_GUIDE.md) for detailed documen
 
 ## Data Sources & Freshness
 
-All content is sourced from authoritative Swedish legal databases:
+All content is sourced from authoritative Danish legal databases:
 
-- **[Riksdagen](https://riksdagen.se/)** -- Swedish Parliament's official legal database
-- **[Svensk Forfattningssamling](https://svenskforfattningssamling.se/)** -- Official statute collection
-- **[Lagen.nu](https://lagen.nu)** -- Case law database (CC-BY Domstolsverket)
+- **[Retsinformation](https://retsinformation.dk/)** -- The official Danish law portal, operated by the Danish Ministry of Justice. Provides the complete corpus of consolidated Danish laws (lovbekendtgørelser), acts (love), and statutory orders (bekendtgørelser).
 - **[EUR-Lex](https://eur-lex.europa.eu/)** -- Official EU law database (metadata only)
+
+### Data Provenance
+
+| Field | Value |
+|-------|-------|
+| **Authority** | Danish Ministry of Justice / Retsinformation |
+| **Retrieval method** | Bulk download from retsinformation.dk API |
+| **Language** | Danish (primary) |
+| **License** | Open data (retsinformation.dk) |
+| **Coverage** | All 62,764 consolidated Danish laws |
+| **Last ingested** | 2026-02-22 |
 
 ### Automated Freshness Checks (Daily)
 
-A [daily GitHub Actions workflow](.github/workflows/check-updates.yml) monitors all data sources:
+A [daily GitHub Actions workflow](.github/workflows/check-updates.yml) monitors retsinformation.dk for changes:
 
 | Source | Check | Method |
 |--------|-------|--------|
-| **Statute amendments** | Riksdagen API date comparison | All 717 statutes checked |
-| **New statutes** | Riksdagen SFS publications (90-day window) | Diffed against database |
-| **Case law** | lagen.nu feed entry count | Compared to database |
-| **Preparatory works** | Riksdagen proposition API (30-day window) | New props detected |
+| **Law amendments** | retsinformation.dk API date comparison | All 62,764 laws checked |
+| **New laws** | retsinformation.dk publications (90-day window) | Diffed against database |
+| **Case law** | Court portal entry count | Compared to database |
+| **Preparatory works** | Lovforslag API (30-day window) | New proposals detected |
 | **EU reference staleness** | Git commit timestamps | Flagged if >90 days old |
 
 The workflow supports `auto_update: true` dispatch for automated sync, rebuild, version bump, and npm publishing.
+
+---
+
+## Premium Tier
+
+The premium tier adds version history, amendment tracking, and extended case law coverage:
+
+| Feature | Free | Premium |
+|---------|------|---------|
+| Full statute corpus (62,764 laws) | Yes | Yes |
+| Full-text search (620,940 provisions) | Yes | Yes |
+| EU law cross-references | Yes | Yes |
+| Citation validation | Yes | Yes |
+| Case law (3,918 rulings) | No | Yes |
+| Preparatory works (4,412 documents) | No | Yes |
+| Amendment history (`get_*_history`) | No | Yes |
+| Version diff (`diff_*`) | No | Yes |
+| Recent changes (`get_recent_changes`) | No | Yes |
+
+Premium is enabled via the `PREMIUM_ENABLED` environment variable. Contact [hello@ansvar.ai](mailto:hello@ansvar.ai) for access.
 
 ---
 
@@ -282,17 +305,18 @@ See [SECURITY.md](SECURITY.md) for the full policy and vulnerability reporting.
 
 > **THIS TOOL IS NOT LEGAL ADVICE**
 >
-> Statute text is sourced from official Riksdagen/SFS publications. However:
+> Statute text is sourced from official retsinformation.dk publications (Danish Ministry of Justice). However:
 > - This is a **research tool**, not a substitute for professional legal counsel
-> - **Court case coverage is limited** -- do not rely solely on this for case law research
+> - **Court case coverage in the free tier is limited** -- do not rely solely on this for case law research
 > - **Verify critical citations** against primary sources for court filings
-> - **EU cross-references** are extracted from Swedish statute text, not EUR-Lex full text
+> - **EU cross-references** are extracted from Danish statute text and EUR-Lex metadata, not substitute for full EUR-Lex legal text
+> - **Municipal and regional regulations are not included** -- this covers national Danish law only
 
 **Before using professionally, read:** [DISCLAIMER.md](DISCLAIMER.md) | [PRIVACY.md](PRIVACY.md)
 
 ### Client Confidentiality
 
-Queries go through the Claude API. For privileged or confidential matters, use on-premise deployment. See [PRIVACY.md](PRIVACY.md) for Advokatsamfundet compliance guidance.
+Queries go through the Claude API. For privileged or confidential matters, use on-premise deployment. See [PRIVACY.md](PRIVACY.md) for Advokatsamfundet (Danish Bar Association) compliance guidance.
 
 ---
 
@@ -311,8 +335,8 @@ Queries go through the Claude API. For privileged or confidential matters, use o
 ### Setup
 
 ```bash
-git clone https://github.com/Ansvar-Systems/swedish-law-mcp
-cd swedish-law-mcp
+git clone https://github.com/Ansvar-Systems/Denmark-law-mcp
+cd Denmark-law-mcp
 npm install
 npm run build
 npm test
@@ -328,19 +352,22 @@ npx @anthropic/mcp-inspector node dist/index.js   # Test with MCP Inspector
 ### Data Management
 
 ```bash
-npm run ingest -- <sfs-number> <output.json>   # Ingest statute from Riksdagen
-npm run ingest:cases:full-archive              # Ingest case law (full archive)
-npm run sync:cases                             # Ingest case law (incremental)
-npm run sync:prep-works                        # Sync preparatory works
-npm run extract:definitions                    # Extract legal definitions
-npm run build:db                               # Rebuild SQLite database
-npm run check-updates                          # Check for amendments
+npm run ingest                             # Ingest laws from retsinformation.dk
+npm run ingest:auto-all -- --scope all-laws --dry-run  # Coverage audit
+npm run ingest:auto-all -- --scope all-laws             # Ingest full corpus
+npm run ingest:cases:full-archive          # Ingest case law (full archive)
+npm run sync:cases                         # Ingest case law (incremental)
+npm run sync:prep-works                    # Sync preparatory works
+npm run extract:definitions                # Extract legal definitions
+npm run build:db                           # Rebuild SQLite database
+npm run check-updates                      # Check for amendments
+npm run drift:detect                       # Run drift detection
 ```
 
 ### Performance
 
 - **Search Speed:** <100ms for most FTS5 queries
-- **Database Size:** ~70 MB (efficient, portable)
+- **Database Size:** 1.6 GB (Fly.io deployment due to size)
 - **Reliability:** 100% ingestion success rate
 
 ---
@@ -352,11 +379,17 @@ This server is part of **Ansvar's Compliance Suite** -- MCP servers that work to
 ### [@ansvar/eu-regulations-mcp](https://github.com/Ansvar-Systems/EU_compliance_MCP)
 **Query 49 EU regulations directly from Claude** -- GDPR, AI Act, DORA, NIS2, MiFID II, eIDAS, and more. Full regulatory text with article-level search. `npx @ansvar/eu-regulations-mcp`
 
-### @ansvar/swedish-law-mcp (This Project)
-**Query 717 Swedish statutes directly from Claude** -- DSL, BrB, ABL, MB, and more. Full provision text with EU cross-references. `npx @ansvar/swedish-law-mcp`
+### @ansvar/danish-law-mcp (This Project)
+**Query 62,764 Danish laws directly from Claude** -- Databeskyttelsesloven, Straffeloven, Selskabsloven, Forvaltningsloven, Konkurrenceretten, and more. Full provision text with EU cross-references. `npx @ansvar/danish-law-mcp`
+
+### [@ansvar/swedish-law-mcp](https://github.com/Ansvar-Systems/swedish-law-mcp)
+**Query Swedish statutes directly from Claude** -- DSL, BrB, ABL, and more. Full provision text with EU cross-references. `npx @ansvar/swedish-law-mcp`
+
+### [@ansvar/norwegian-law-mcp](https://github.com/Ansvar-Systems/Norway-law-mcp)
+**Query Norwegian legislation directly from Claude** -- Lovdata corpus with EU EEA cross-references. `npx @ansvar/norwegian-law-mcp`
 
 ### [@ansvar/us-regulations-mcp](https://github.com/Ansvar-Systems/US_Compliance_MCP)
-**Query US federal and state compliance laws** -- HIPAA, CCPA, SOX, GLBA, FERPA, and more. `npm install @ansvar/us-regulations-mcp`
+**Query US federal and state compliance laws** -- HIPAA, CCPA, SOX, GLBA, FERPA, and more. `npx @ansvar/us-regulations-mcp`
 
 ### [@ansvar/ot-security-mcp](https://github.com/Ansvar-Systems/ot-security-mcp)
 **Query IEC 62443, NIST 800-82/53, and MITRE ATT&CK for ICS** -- Specialized for OT/ICS environments. `npx @ansvar/ot-security-mcp`
@@ -367,6 +400,8 @@ This server is part of **Ansvar's Compliance Suite** -- MCP servers that work to
 ### [@ansvar/sanctions-mcp](https://github.com/Ansvar-Systems/Sanctions-MCP)
 **Offline-capable sanctions screening** -- OFAC, EU, UN sanctions lists. `pip install ansvar-sanctions-mcp`
 
+**70+ national law MCPs** covering Australia, Belgium, Brazil, Canada, Finland, France, Germany, Ghana, Iceland, India, Ireland, Israel, Italy, Japan, Kenya, Netherlands, Nigeria, Norway, Poland, Singapore, Slovenia, South Korea, Sweden, Switzerland, Thailand, UAE, UK, and more.
+
 ---
 
 ## Contributing
@@ -374,20 +409,23 @@ This server is part of **Ansvar's Compliance Suite** -- MCP servers that work to
 Contributions welcome! See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
 
 Priority areas:
-- Court case law expansion (currently limited coverage)
+- Court case law expansion (Højesteret and Landsretter full archives)
 - EU Regulations MCP integration (full EU law text, CJEU case law)
 - Historical statute versions and amendment tracking
-- Lower court decisions (Tingsrätt, Hovrätt)
+- Lower court decisions (Byretter archives)
+- English translations for key statutes
 
 ---
 
 ## Roadmap
 
-- [x] **Statute expansion** -- 785% growth from 81 to 717 statutes (v1.1.0)
-- [x] **EU law integration** -- 668 cross-references to 228 EU directives/regulations (v1.1.0)
-- [ ] Court case law expansion (scraper updated, re-ingestion needed for 12K-18K cases)
+- [x] **Full corpus ingestion** -- 62,764 Danish laws from retsinformation.dk
+- [x] **EU law integration** -- Danish statute transposition cross-references
+- [x] **Premium tier** -- case law (3,918 rulings) and preparatory works (4,412 documents)
+- [x] **Fly.io deployment** -- 1.6 GB database hosted on Fly.io
+- [x] **npm package publication** -- `@ansvar/danish-law-mcp`
+- [ ] Court case law expansion (Byretter full archives)
 - [ ] Full EU text integration (via @ansvar/eu-regulations-mcp)
-- [ ] Lower court coverage (Tingsrätt, Hovrätt archives)
 - [ ] Historical statute versions (amendment tracking)
 - [ ] English translations for key statutes
 - [ ] Web API for programmatic access
@@ -399,12 +437,12 @@ Priority areas:
 If you use this MCP server in academic research:
 
 ```bibtex
-@software{swedish_law_mcp_2025,
+@software{danish_law_mcp_2026,
   author = {Ansvar Systems AB},
-  title = {Swedish Law MCP Server: Production-Grade Legal Research Tool},
-  year = {2025},
-  url = {https://github.com/Ansvar-Systems/swedish-law-mcp},
-  note = {Comprehensive Swedish legal database with 717 statutes and EU law cross-references}
+  title = {Danish Law MCP Server: Production-Grade Legal Research Tool},
+  year = {2026},
+  url = {https://github.com/Ansvar-Systems/Denmark-law-mcp},
+  note = {Comprehensive Danish legal database with 62,764 laws and 620,940 provisions from retsinformation.dk}
 }
 ```
 
@@ -416,17 +454,17 @@ Apache License 2.0. See [LICENSE](./LICENSE) for details.
 
 ### Data Licenses
 
-- **Statutes & Propositions:** Swedish Government (public domain)
-- **Case Law:** CC-BY Domstolsverket (via lagen.nu)
+- **Laws & Statutory Orders:** Danish Ministry of Justice via retsinformation.dk (open data)
+- **Case Law:** Højesteret and Landsretter (Danish court system)
 - **EU Metadata:** EUR-Lex (EU public domain)
 
 ---
 
 ## About Ansvar Systems
 
-We build AI-accelerated compliance and legal research tools for the European market. This MCP server started as our internal reference tool for Swedish law -- turns out everyone building for the Swedish market has the same research frustrations.
+We build AI-accelerated compliance and legal research tools for the European market. This MCP server started as our internal reference tool for Danish law -- turns out everyone building for the Danish and Nordic markets has the same research frustrations.
 
-So we're open-sourcing it. Navigating 717 statutes shouldn't require a law degree.
+So we're open-sourcing it. Navigating 62,764 laws on retsinformation.dk shouldn't require a law degree.
 
 **[ansvar.eu](https://ansvar.eu)** -- Stockholm, Sweden
 


### PR DESCRIPTION
## Summary

- Replaces the existing README with the fleet golden-standard README tailored for Danish Law MCP
- Covers the full corpus (62,764 laws, 620,940 provisions from retsinformation.dk), Fly.io deployment rationale (1.6 GB DB exceeds Vercel 50 MB limit), and premium tier (3,918 case law rulings, 4,412 preparatory works)
- Includes Danish-language example queries, EU integration section noting Denmark's full EU membership with opt-out context, data provenance table, tool reference, security scanning table, related projects, and contributing/roadmap sections

## Test plan

- [ ] Verify all links resolve (EU_INTEGRATION_GUIDE.md, EU_USAGE_EXAMPLES.md, SECURITY.md, DISCLAIMER.md, PRIVACY.md)
- [ ] Confirm endpoint `https://danish-law-mcp.fly.dev/mcp` is live before merge to main
- [ ] Check npm badge resolves against `@ansvar/danish-law-mcp`

🤖 Generated with [Claude Code](https://claude.com/claude-code)