### PR TITLE
fix: accept article param in get_provision for fleet audit compatibility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "@types/node": "^22.15.29",
         "@vercel/node": "^5.6.3",
         "@vitest/coverage-v8": "^4.0.18",
+        "better-sqlite3": "npm:@ansvar/mcp-sqlite@^1.0.3",
         "fast-xml-parser": "^5.3.5",
         "jsdom": "^27.4.0",
         "tsx": "^4.21.0",
@@ -2437,6 +2438,20 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/better-sqlite3": {
+      "name": "@ansvar/mcp-sqlite",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@ansvar/mcp-sqlite/-/mcp-sqlite-1.0.4.tgz",
+      "integrity": "sha512-oFo12sDozxWQRKqTMSdspqZM2RtC2Sl5/Se40k4OOBtIvGTUSKZvNbQBcotIxhoWO4unthEOZqWAQ07Fv1vzWw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "node-sqlite3-wasm": "^0.8.53"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/bidi-js": {
       "version": "1.0.3",

--- a/src/tools/get-provision.ts
+++ b/src/tools/get-provision.ts
@@ -10,6 +10,7 @@ export interface GetProvisionInput {
   document_id: string;
   chapter?: string;
   section?: string;
+  article?: string;
   provision_ref?: string;
   as_of_date?: string;
 }
@@ -64,6 +65,8 @@ export async function getProvision(
       provisionRef = `${input.chapter}:${input.section}`;
     } else if (input.section) {
       provisionRef = input.section;
+    } else if (input.article) {
+      provisionRef = input.article;
     }
   }
 


### PR DESCRIPTION
## Summary

- Adds `article?: string` to `GetProvisionInput` interface in `get-provision.ts`
- Extends provision ref resolution to fall back to `input.article` when both `provision_ref` and `section` are absent
- Also includes updated `package-lock.json` (adds missing `better-sqlite3` alias entry that was breaking `npm ci` in CI)

Fleet audit sends `{"document_id": "...", "article": "1"}` — the tool was silently ignoring `article`, returning empty content instead of the requested provision.

## Test plan
- [x] `tsc --noEmit` passes locally
- [x] Squash-merged to `dev` via PR #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)