### PR TITLE
fix: resolve Databeskyttelsesloven identifier in A2 audit

### DIFF
--- a/src/tools/get-provision.ts
+++ b/src/tools/get-provision.ts
@@ -4,6 +4,7 @@
 
 import type { Database } from '@ansvar/mcp-sqlite';
 import { normalizeAsOfDate } from '../utils/as-of-date.js';
+import { resolveDocumentId } from '../utils/statute-id.js';
 import { generateResponseMetadata, type ToolResponse } from '../utils/metadata.js';
 
 export interface GetProvisionInput {
@@ -58,6 +59,8 @@ export async function getProvision(
     throw new Error('document_id is required');
   }
 
+  const documentId = resolveDocumentId(db, input.document_id) ?? input.document_id;
+
   // If provision_ref is directly provided, use it
   let provisionRef = input.provision_ref;
   if (!provisionRef) {
@@ -75,7 +78,7 @@ export async function getProvision(
   // If no specific provision, return all provisions for the document
   if (!provisionRef) {
     return {
-      results: getAllProvisions(db, input.document_id, asOfDate),
+      results: getAllProvisions(db, documentId, asOfDate),
       _metadata: generateResponseMetadata(db)
     };
   }
@@ -104,7 +107,7 @@ export async function getProvision(
       ORDER BY COALESCE(lpv.valid_from, '0000-01-01') DESC, lpv.id DESC
       LIMIT 1
     `;
-    row = db.prepare(sql).get(input.document_id, provisionRef, asOfDate, asOfDate) as ProvisionRow | undefined;
+    row = db.prepare(sql).get(documentId, provisionRef, asOfDate, asOfDate) as ProvisionRow | undefined;
   } else {
     const sql = `
       SELECT
@@ -123,7 +126,7 @@ export async function getProvision(
       JOIN legal_documents ld ON ld.id = lp.document_id
       WHERE lp.document_id = ? AND lp.provision_ref = ?
     `;
-    row = db.prepare(sql).get(input.document_id, provisionRef) as ProvisionRow | undefined;
+    row = db.prepare(sql).get(documentId, provisionRef) as ProvisionRow | undefined;
   }
 
   if (!row) {
@@ -137,7 +140,7 @@ export async function getProvision(
     SELECT target_document_id, target_provision_ref, ref_type
     FROM cross_references
     WHERE source_document_id = ? AND (source_provision_ref = ? OR source_provision_ref IS NULL)
-  `).all(input.document_id, provisionRef) as CrossRefResult[];
+  `).all(documentId, provisionRef) as CrossRefResult[];
 
   return {
     results: {

--- a/src/utils/statute-id.ts
+++ b/src/utils/statute-id.ts
@@ -26,6 +26,10 @@ interface DocRow {
 
 const ABBREVIATIONS: Record<string, string> = {
   // Example: 'DPA': 'data-protection-act-2019',
+  // Danish Data Protection Act (Databeskyttelsesloven) — consolidated 2024
+  'Databeskyttelsesloven': '2024:289',
+  'databeskyttelsesloven': '2024:289',
+  'DATABESKYTTELSESLOVEN': '2024:289',
 };
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Adds ABBREVIATIONS entries for `Databeskyttelsesloven` / `databeskyttelsesloven` / `DATABESKYTTELSESLOVEN` → `2024:289` in `src/utils/statute-id.ts`
- Wires `resolveDocumentId` into `src/tools/get-provision.ts` — this file previously passed `document_id` straight to SQL with no resolution step, causing A2 lowercase-identifier audit failures

## Root cause

The A2 audit test lowercases `"Databeskyttelsesloven"` to `"databeskyttelsesloven"` and calls `get_provision` with that value. Danish `get-provision.ts` had no statute-id resolution — unlike the French equivalent which already imports `resolveExistingStatuteId`. Even after adding the resolution import, the cascade's step 6 case-insensitive title scan would not match because `"databeskyttelsesloven"` only appears inside a long parenthetical in the stored title, while in practice users pass the short popular name. The abbreviation map (step 2) provides a guaranteed, O(1) resolution path.

## Also: fleet manifest article fix

The Danish data protection law provisions use `chapter:section` format (`"1:1"`, `"2:4"`, etc.). The fleet manifest `known_law.article` was set to `"1"` which produces no match. Updated to `"1:1"` in `backstage/catalog/fleet-manifests/danish-law.json` (in the arch-doc repo, not this PR).

## Test plan

- [ ] `npm run build` passes (verified locally — zero errors)
- [ ] Deploy to dev, verify A2 audit: `get_provision {document_id: "databeskyttelsesloven", article: "1:1"}` returns `"personoplysninger"` in content
- [ ] Verify existing A1 (exact ID `"2024:289"`) still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)