### PR TITLE
fix: bump mcp-sqlite to 1.0.5 + repair ghcr-build (unblocks law-danish prod crash-loop)

### DIFF
--- a/.github/workflows/ghcr-build.yml
+++ b/.github/workflows/ghcr-build.yml
@@ -89,13 +89,27 @@ jobs:
               exit 1
             fi
 
-            echo "Downloading database.db.gz from release $TAG..."
+            echo "Downloading *.db.gz from release $TAG..."
             mkdir -p data
-            if gh release download "$TAG" -p "database.db.gz" -D data/ 2>/dev/null; then
-              gunzip -f data/database.db.gz
-              echo "OK: Downloaded $(du -sh data/database.db | cut -f1) from release $TAG"
+            # Match any .db.gz asset; some MCPs publish database.db.gz, others publish <name>-free.db.gz
+            if gh release download "$TAG" -p "*.db.gz" -D data/ 2>/dev/null; then
+              for gz in data/*.db.gz; do
+                [ -e "$gz" ] || continue
+                gunzip -f "$gz"
+              done
+              # Normalize to data/database.db so the Dockerfile COPY succeeds regardless of asset naming
+              if [ ! -f data/database.db ]; then
+                first_db=$(ls data/*.db 2>/dev/null | head -1)
+                [ -n "$first_db" ] && mv "$first_db" data/database.db
+              fi
+              if [ -f data/database.db ]; then
+                echo "OK: $(du -sh data/database.db | cut -f1) from release $TAG"
+              else
+                echo "ERROR: archive downloaded but no .db file produced"
+                exit 1
+              fi
             else
-              echo "ERROR: Could not download database.db.gz from release $TAG"
+              echo "ERROR: Could not download *.db.gz from release $TAG"
               exit 1
             fi
           done

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,9 @@
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@ansvar/mcp-sqlite": "^1.0.3",
-        "@modelcontextprotocol/sdk": "^1.25.3"
+        "@ansvar/mcp-sqlite": "^1.0.5",
+        "@modelcontextprotocol/sdk": "^1.25.3",
+        "better-sqlite3": "^12.6.2"
       },
       "bin": {
         "danish-law-mcp": "dist/index.js"
@@ -21,7 +22,7 @@
         "@types/node": "^22.15.29",
         "@vercel/node": "^5.6.3",
         "@vitest/coverage-v8": "^4.0.18",
-        "better-sqlite3": "npm:@ansvar/mcp-sqlite@^1.0.3",
+        "better-sqlite3": "npm:@ansvar/mcp-sqlite@^1.0.5",
         "fast-xml-parser": "^5.3.5",
         "jsdom": "^27.4.0",
         "tsx": "^4.21.0",
@@ -40,9 +41,9 @@
       "license": "MIT"
     },
     "node_modules/@ansvar/mcp-sqlite": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@ansvar/mcp-sqlite/-/mcp-sqlite-1.0.3.tgz",
-      "integrity": "sha512-e4kS/84VOUU9YBAU+ls9KhouVA9gPHZAcuHjxTZP9ZyCnknlkOEI9yzYGnsNQdDT3a6d+rvDNPdu1dgaUtH5yg==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@ansvar/mcp-sqlite/-/mcp-sqlite-1.0.5.tgz",
+      "integrity": "sha512-RsdxHZhLzyQkpPGQJ2w59O7m/aHtRYHa5ymThI+mJykAnb+qjCJClBK+E/bo40miUhyXqz4VFe0MztOYQgfJRg==",
       "license": "Apache-2.0",
       "dependencies": {
         "node-sqlite3-wasm": "^0.8.53"
@@ -2439,9 +2440,9 @@
     },
     "node_modules/better-sqlite3": {
       "name": "@ansvar/mcp-sqlite",
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@ansvar/mcp-sqlite/-/mcp-sqlite-1.0.4.tgz",
-      "integrity": "sha512-oFo12sDozxWQRKqTMSdspqZM2RtC2Sl5/Se40k4OOBtIvGTUSKZvNbQBcotIxhoWO4unthEOZqWAQ07Fv1vzWw==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@ansvar/mcp-sqlite/-/mcp-sqlite-1.0.5.tgz",
+      "integrity": "sha512-RsdxHZhLzyQkpPGQJ2w59O7m/aHtRYHa5ymThI+mJykAnb+qjCJClBK+E/bo40miUhyXqz4VFe0MztOYQgfJRg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -46,12 +46,12 @@
     "postinstall": "test -d dist || npm run build || true"
   },
   "dependencies": {
-    "@ansvar/mcp-sqlite": "^1.0.3",
+    "@ansvar/mcp-sqlite": "^1.0.5",
     "@modelcontextprotocol/sdk": "^1.25.3",
     "better-sqlite3": "^12.6.2"
   },
   "devDependencies": {
-    "better-sqlite3": "npm:@ansvar/mcp-sqlite@^1.0.3",
+    "better-sqlite3": "npm:@ansvar/mcp-sqlite@^1.0.5",
     "@types/jsdom": "^21.1.7",
     "@types/node": "^22.15.29",
     "@vercel/node": "^5.6.3",


### PR DESCRIPTION
## Why

Production container `law-danish` is crash-looping with `SQLite3Error: database is locked` at `detectCapabilities` (boot) — watchdog `cf=234` (~12h of consecutive failures), Docker `RestartCount=705+`. This is the documented **VFS `.lock/` persistence bug** (Issue B in `docs/known-issues/wasm-sqlite-overlay-filesystem.md`).

The fix exists upstream (`@ansvar/mcp-sqlite@1.0.5`, commit `05713c4`) but cannot reach prod because of a *second*, separate bug in this repo's GHCR build pipeline.

## What

Two coupled changes:

### 1. Bump `@ansvar/mcp-sqlite` ^1.0.3 → ^1.0.5

`package-lock.json` was pinned to `1.0.3` despite the caret range, so `npm ci` in the Dockerfile installs the broken version on every build. v1.0.5's constructor adds 11 additive lines that `rmSync` the stale `<path>.lock/` directory before opening — zero behavioral change for existing callers.

### 2. Repair `ghcr-build.yml` database provisioning

Existing workflow downloads an asset by exact name `database.db.gz`. This repo's release asset is `danish-free.db.gz`. Result: **8 consecutive workflow failures since 2026-04-03**; the deployed image is dated **2026-04-02** (35 days stale). Generalized to glob `*.db.gz` and normalize the unzipped filename to `data/database.db` — works for both Cypriot's naming and ours.

## Failure log evidence

Last failed run (PR #45 merge, 2026-04-11):
```
WARN: data/database.db does not exist
Downloading database.db.gz from release v1.0.1...
ERROR: Could not download database.db.gz from release v1.0.1
```

## Verification

- `npm install --package-lock-only` resolves `@ansvar/mcp-sqlite` to `1.0.5`.
- v1.0.3 → v1.0.5 source diff is purely additive (constructor only).
- `python3 -c "import yaml; yaml.safe_load(...)"` validates the workflow.

## Deploy plan

After merge:
1. `ghcr-build.yml` builds + pushes `:latest` within ~5 min (first successful build since 2026-04-02).
2. Watchtower (1h poll on prod) pulls the new image; container swap creates a fresh overlay layer (eliminates the current stale `.lock/`).
3. The new image's v1.0.5 constructor prevents recurrence on any future crash/OOM.

## Notes

- **Base = `main`** — `dev` branch is 5 commits behind main and effectively abandoned; verifying via dev would require a sync-PR first. Open to changing if you'd rather route through dev.
- **No version field bumped** in `package.json` — won't trigger the tag-only `publish.yml` (npm package is intentionally deprecated per `project_npm_fleet_deprecated_2026_05_02`).
- **Expected ruleset friction:** law-mcp-main ruleset has 6 phantom required checks. Mexican-law was unblocked 2026-05-02; Danish wasn't swept. May need ruleset edit before this can merge.