### PR TITLE
feat(ci): Watchtower kick on main build (eliminate Watchtower silent-skip)

### DIFF
--- a/.github/workflows/ghcr-build.yml
+++ b/.github/workflows/ghcr-build.yml
@@ -6,9 +6,14 @@
 # - main: pushes :latest and :sha-XXXXXXX tags
 # - dev:  pushes :dev and :sha-XXXXXXX tags
 #
-# Watchtower on the Hetzner prod server polls GHCR every 6 hours and
-# automatically restarts containers when a new :latest image is detected.
-# No manual deploy step needed.
+# After a successful main-branch build, this workflow also POSTs to
+# Watchtower's /v1/update HTTP API on the Hetzner prod server, which
+# triggers an immediate scan + restart for any mcp-scope container with a
+# new :latest image. This makes prod swap within seconds of merge instead
+# of waiting up to 1h for the next periodic poll. The kick is best-effort
+# (continue-on-error) — if the secret is missing or the endpoint is down,
+# the existing hourly poll remains as a safety net. Same pattern as
+# ansvar-mcp-gateway/.github/workflows/deploy.yml.
 #
 # DATABASE PROVISIONING:
 # If the Dockerfile COPYs a .db file and that file is missing, empty, or an
@@ -144,6 +149,31 @@ jobs:
           platforms: linux/amd64
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+      - name: Trigger Watchtower update on prod
+        if: success() && github.ref == 'refs/heads/main'
+        continue-on-error: true
+        env:
+          WATCHTOWER_TOKEN: ${{ secrets.WATCHTOWER_HTTP_API_TOKEN }}
+        run: |
+          if [ -z "$WATCHTOWER_TOKEN" ]; then
+            echo "WATCHTOWER_HTTP_API_TOKEN not set — skipping kick. Prod will swap on next hourly Watchtower poll."
+            echo "To enable near-instant deploys, add this secret to the repo (value lives in /opt/ansvar/prod/mcp/watchtower/.env on the prod host)."
+            exit 0
+          fi
+          echo "Kicking Watchtower /v1/update..."
+          HTTP=$(curl -X POST -sS -o /tmp/watchtower-response \
+            -H "Authorization: Bearer $WATCHTOWER_TOKEN" \
+            -w "%{http_code}" \
+            https://watchtower.ansvar.eu/v1/update) || HTTP="000"
+          echo "Response code: $HTTP"
+          head -c 500 /tmp/watchtower-response 2>/dev/null || true
+          echo
+          if [ "$HTTP" = "200" ]; then
+            echo "OK: Watchtower scan triggered — prod should swap law-danish within seconds."
+          else
+            echo "WARN: Watchtower kick returned HTTP $HTTP. Hourly poll will swap eventually."
+          fi
 
       - name: Summary
         if: always()


### PR DESCRIPTION
## Why

Today's law-danish recovery (PR #53) exposed a recurring deploy failure mode: a fix can be correct on main, the GHCR build can succeed, the new image can be in the registry — and the prod container can still run the old image indefinitely because Watchtower's hourly poll silently no-ops on the mismatch.

Concrete data from this morning:
- Image was last built 2026-04-02 (35 days stale).
- Two successful GHCR builds today (07:13 and 08:24 UTC).
- Three Watchtower polls after the builds (07:42, 08:42, 14:42 UTC).
- Each poll: \`Failed=0 Scanned=245 Updated=0\` — Watchtower never logged \"Found new image\" for danish-law-mcp.
- Recovery required a manual \`docker compose up -d --force-recreate danish\` with the premium override file.

Root cause of Watchtower's silent skip is unclear (possibly tag-cache poisoning, possibly a HEAD-request etag issue), but the practical answer is the same as what the gateway repo already does: don't depend on Watchtower's polling correctness — kick it explicitly after every successful main build.

## What

After \`Build and push\`, on \`main\` only, POST to \`https://watchtower.ansvar.eu/v1/update\` with the bearer token. Mirrors \`ansvar-mcp-gateway/.github/workflows/deploy.yml\`.

Properties:
- **Main-only** (\`if: github.ref == 'refs/heads/main'\`) — no production swap on dev pushes.
- **Best-effort** (\`continue-on-error: true\`) — missing secret or down endpoint logs and exits 0; the hourly poll remains as a safety net.
- **\`env:\` indirection** for the secret, not inline in \`run:\` — the safe-pattern flagged by [GitHub's workflow injection guide](https://github.blog/security/vulnerability-research/how-to-catch-github-actions-workflow-injections-before-attackers-do/).
- **HTTP status + body capture** in the log so auth/connectivity failures are debuggable.

## Verification

- \`yaml.safe_load\` validates.
- Diff: 33 insertions, 3 deletions (one new step + header comment update).
- Step is no-op without the secret — won't break anything if you merge before adding it.

## Required after merge

Add \`WATCHTOWER_HTTP_API_TOKEN\` as a repo secret (or — preferred — as an **org secret** with selected-repos visibility so the fleet sweep below doesn't need per-repo configuration).

Value: same token used by \`ansvar-mcp-gateway\`. Lives in \`/opt/ansvar/prod/mcp/watchtower/.env\` on the prod host:

\`\`\`
ssh deploy@65.21.243.67 'grep WATCHTOWER_HTTP_API_TOKEN /opt/ansvar/prod/mcp/watchtower/.env'
\`\`\`

Without the secret, the step prints a clear informational message and exits 0; subsequent deploys continue to rely on the 1h Watchtower poll.

## Follow-up — fleet sweep

Once verified on Danish, propagate the one-step addition to:
- Cypriot-law-mcp
- Swedish-law-mcp
- Dutch-law-mcp
- German-law-mcp
- French-law-mcp
- ~100 other law-mcp repos that already have ghcr-build.yml

Mechanical port; can be a single arch-docs PR if we templatize via \`scripts/templates/mcp-workflows/\`.