### PR TITLE
chore: sync license to DK-Statutory-PD per arch-docs 2026-05-17

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ All content is sourced from authoritative Danish legal databases:
 | **Authority** | Danish Ministry of Justice / Retsinformation |
 | **Retrieval method** | Bulk download from retsinformation.dk API |
 | **Language** | Danish (primary) |
-| **License** | Open data (retsinformation.dk) |
+| **License** | `DK-Statutory-PD` — Danish statutory public domain (Ophavsretsloven §9) |
 | **Coverage** | All 62,764 consolidated Danish laws |
 | **Last ingested** | 2026-02-22 |
 
@@ -391,9 +391,9 @@ Apache License 2.0. See [LICENSE](./LICENSE) for details.
 
 ### Data Licenses
 
-- **Laws & Statutory Orders:** Danish Ministry of Justice via retsinformation.dk (open data)
-- **Case Law:** Højesteret and Landsretter (Danish court system)
-- **EU Metadata:** EUR-Lex (EU public domain)
+- **Laws & Statutory Orders:** `DK-Statutory-PD` — Danish statutory public domain. Ophavsretsloven §9 excludes laws, administrative orders, regulations, court decisions, and similar acts issued by a public authority from copyright protection. Verified verbatim 2026-05-17 — see [`docs/audits/2026-05-17-eu-copyright-statutory-works-batch-1a-AT-BE-DK-FI-FR.md`](https://github.com/Ansvar-Systems/Ansvar-Architecture-Documentation/blob/main/docs/audits/2026-05-17-eu-copyright-statutory-works-batch-1a-AT-BE-DK-FI-FR.md). Catalog entry: `DK-Statutory-PD` in `infrastructure/attribution-licenses.json`.
+- **Case Law:** Højesteret and Landsretter — same statutory basis (Ophavsretsloven §9 court-decision clause)
+- **EU Metadata:** EUR-Lex (EU public domain, Decision 2011/833/EU)
 
 ---
 

--- a/sources.yml
+++ b/sources.yml
@@ -1,3 +1,11 @@
+# sources.yml — Data provenance metadata
+# License axis: DK-Statutory-PD (Danish statutory public domain)
+# Statutory basis: Ophavsretsloven §9 — laws, administrative orders,
+# regulations, court decisions, and similar acts of public authority are
+# excluded from copyright protection. Verified verbatim 2026-05-17.
+# Cross-ref: docs/audits/2026-05-17-eu-copyright-statutory-works-batch-1a-AT-BE-DK-FI-FR.md
+# Catalog entry: infrastructure/attribution-licenses.json → "DK-Statutory-PD"
+
 schema_version: '1.0'
 mcp_name: 'Danish Law MCP'
 jurisdiction: 'DK'
@@ -13,9 +21,9 @@ sources:
     last_ingested: '2026-02-14'
     last_verified: '2026-05-09'
     license_or_terms:
-      type: 'Government Open Data'
-      url: 'https://www.retsinformation.dk/offentliggoerelser/LDA-ophavsret'
-      summary: 'Danish legislation is public domain; free to use'
+      type: 'DK-Statutory-PD'
+      url: 'https://www.retsinformation.dk/eli/lta/2023/1093'
+      summary: 'Danish statutory public domain (Ophavsretsloven §9). Laws, administrative orders, regulations, court decisions, and similar acts issued by a public authority are excluded from copyright protection. Statute-level basis on the underlying text.'
     coverage:
       scope: 'Danish statutes (love, bekendtgørelser, cirkulærer)'
       limitations: 'Historical consolidations depend on Retsinformation coverage'


### PR DESCRIPTION
## Summary

Replace generic license declaration with the jurisdiction-specific statutory-PD code that landed in arch-docs catalog today.

- `sources.yml` license type updated to `DK-Statutory-PD`
- README data-licenses block points at the statutory section and the new catalog entry

## Statutory basis

Ophavsretsloven §9 — laws, administrative orders, regulations, court decisions, and similar acts of public authority excluded from copyright protection. Verified verbatim 2026-05-17.

## Scope

License-axis sync only. No corpus content, ingestion code, or runtime behaviour changes.

## Cross-references

- `docs/audits/2026-05-17-eu-copyright-statutory-works-batch-1a-AT-BE-DK-FI-FR.md` (arch-docs)
- `infrastructure/attribution-licenses.json` → `DK-Statutory-PD` (arch-docs)

## Test plan

- [ ] CI green (7 workflows + tests)
- [ ] No diff in `data/` or `src/` (license-axis only)