### PR TITLE
fix(ingest): corpus version-pin repair — explicit status mapping, _ingest stamping, fail-loud refresh (#89)

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,8 @@
     "coverage:update": "tsx scripts/update-coverage.ts",
     "freshness:check": "tsx scripts/check-freshness.ts",
     "coverage:verify": "tsx scripts/verify-coverage.ts",
-    "ingest:full": "npm run ingest:fetch && npm run build:db && npm run coverage:update"
+    "ingest:full": "npm run ingest:fetch && npm run build:db && npm run coverage:update",
+    "ingest:refresh": "node --import tsx scripts/auto-ingest-all-statutes.ts --refresh"
   },
   "dependencies": {
     "@ansvar/mcp-sqlite": "^1.0.5",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "test:coverage": "vitest run --coverage",
     "ingest": "tsx scripts/ingest-retsinformation.ts",
     "ingest:document": "tsx scripts/ingest-retsinformation.ts",
-    "ingest:relevant": "tsx scripts/ingest-relevant-laws.ts",
     "ingest:auto-all": "node --import tsx scripts/auto-ingest-all-statutes.ts",
     "ingest:domsdatabasen": "node --import tsx scripts/ingest-domsdatabasen.ts",
     "ingest:folketinget": "node --import tsx scripts/ingest-folketinget.ts",

--- a/scripts/auto-ingest-all-statutes.ts
+++ b/scripts/auto-ingest-all-statutes.ts
@@ -1,28 +1,54 @@
 #!/usr/bin/env tsx
 /**
- * Automated bulk ingestion of Danish laws from Retsinformation sitemap.
+ * Automated bulk ingestion + corpus refresh for Danish laws from
+ * Retsinformation (issue #89).
  *
  * Source flow:
- *   sitemap.xml -> /eli/lta/{year}/{number} URLs -> /xml payload -> seed JSON
+ *   sitemap.xml -> /eli/lta/{year}/{number} URLs (UNION with held seeds)
+ *   -> /xml payload -> stamped seed JSON
+ *
+ * Modes:
+ *   default      additive: only documents without a seed are fetched
+ *   --refresh    version-keyed refresh: unstamped seeds self-heal
+ *                unconditionally; stamped seeds refetch unless proven
+ *                current (see scripts/lib/refresh-policy.ts)
+ *
+ * Fail-loud contract:
+ *   - transient fetch failures retry with backoff, then count as FAILED —
+ *     never as "document gone"; the run continues and exits 2 at the end.
+ *   - HTTP 404/410 is positive gone-evidence: enumerated in the report,
+ *     seed kept, exit code unaffected.
+ *   - every failed/gone document is enumerated in the JSON report.
+ *
+ * Politeness: >= 2s start-to-start pacing against retsinformation.dk; one
+ * request in flight at a time.
  *
  * Usage:
  *   node --import tsx scripts/auto-ingest-all-statutes.ts
- *   node --import tsx scripts/auto-ingest-all-statutes.ts --limit 500
- *   node --import tsx scripts/auto-ingest-all-statutes.ts --year-start 2015 --year-end 2026
- *   node --import tsx scripts/auto-ingest-all-statutes.ts --dry-run
+ *   node --import tsx scripts/auto-ingest-all-statutes.ts --refresh
+ *   node --import tsx scripts/auto-ingest-all-statutes.ts --refresh \
+ *     --skip-stamped-since 2026-06-11T00:00:00Z   # resume interrupted run
+ *   node --import tsx scripts/auto-ingest-all-statutes.ts --limit 500 --dry-run
+ *
+ * Exit codes: 0 = complete; 1 = fatal; 2 = partial (failures enumerated).
  */
 
 import * as fs from 'fs';
 import * as path from 'path';
 import { fileURLToPath } from 'url';
-import { ingest } from './ingest-retsinformation.js';
+import { ingest, GoneUpstreamError } from './ingest-retsinformation.js';
+import { decideFetch, type SeedIngestMeta } from './lib/refresh-policy.js';
+import { buildWorklist, summarizeRun, type SitemapEntry, type WorkItem, type RunStats } from './lib/refresh-worklist.js';
+import { fetchWithRetry } from './lib/http-retry.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
 const SITEMAP_INDEX_URL = 'https://www.retsinformation.dk/sitemap.xml';
 const OUTPUT_DIR = path.resolve(__dirname, '../data/seed');
-const REQUEST_DELAY_MS = 350;
+const REPORT_DIR = path.resolve(__dirname, '../reports');
+/** Politeness floor for retsinformation.dk: 2s start-to-start, sequential. */
+const REQUEST_DELAY_MS = 2_000;
 const USER_AGENT = 'Danish-Law-MCP/1.0.0 (bulk-ingest)';
 
 interface CLIOptions {
@@ -30,31 +56,18 @@ interface CLIOptions {
   yearStart?: number;
   yearEnd?: number;
   dryRun: boolean;
-  skipExisting: boolean;
+  refresh: boolean;
+  skipStampedSince?: string;
   maxPages?: number;
   delayMs: number;
-}
-
-interface LawEntry {
-  url: string;
-  year: number;
-  number: number;
-  lastmod?: string;
-}
-
-interface IngestionStats {
-  total: number;
-  skipped: number;
-  succeeded: number;
-  failed: number;
-  errors: Array<{ id: string; error: string }>;
+  reportPath?: string;
 }
 
 function parseArgs(): CLIOptions {
   const args = process.argv.slice(2);
   const options: CLIOptions = {
     dryRun: false,
-    skipExisting: true,
+    refresh: false,
     delayMs: REQUEST_DELAY_MS,
   };
 
@@ -80,19 +93,36 @@ function parseArgs(): CLIOptions {
       case '--dry-run':
         options.dryRun = true;
         break;
+      case '--refresh':
+        options.refresh = true;
+        break;
+      case '--skip-stamped-since':
+        options.skipStampedSince = args[++i];
+        break;
+      case '--report':
+        options.reportPath = args[++i];
+        break;
       case '--no-skip':
-        options.skipExisting = false;
+        // Legacy alias: a full refetch regardless of stamps is --refresh
+        // without --skip-stamped-since.
+        options.refresh = true;
         break;
       default:
-        break;
+        throw new Error(`Unknown argument: ${arg}`);
     }
+  }
+
+  if (options.delayMs < REQUEST_DELAY_MS && !options.dryRun) {
+    throw new Error(
+      `--delay-ms ${options.delayMs} is below the ${REQUEST_DELAY_MS}ms politeness floor for retsinformation.dk`,
+    );
   }
 
   return options;
 }
 
 async function fetchText(url: string): Promise<string> {
-  const response = await fetch(url, {
+  const response = await fetchWithRetry(url, {
     headers: {
       Accept: 'application/xml,text/xml,*/*',
       'User-Agent': USER_AGENT,
@@ -120,7 +150,7 @@ function extractSitemapLocs(xml: string): string[] {
 
 function extractUrlEntries(xml: string): Array<{ loc: string; lastmod?: string }> {
   const entries: Array<{ loc: string; lastmod?: string }> = [];
-  const pattern = /<url>\s*<loc>([^<]+)<\/loc>(?:<lastmod>([^<]+)<\/lastmod>)?<\/url>/g;
+  const pattern = /<url>\s*<loc>([^<]+)<\/loc>\s*(?:<lastmod>([^<]+)<\/lastmod>)?\s*<\/url>/g;
 
   for (const match of xml.matchAll(pattern)) {
     const loc = match[1]?.trim();
@@ -133,10 +163,6 @@ function extractUrlEntries(xml: string): Array<{ loc: string; lastmod?: string }
   }
 
   return entries;
-}
-
-function isLtaUrl(url: string): boolean {
-  return /\/eli\/lta\/\d{4}\/\d+$/u.test(url);
 }
 
 function parseLawIdFromUrl(url: string): { year: number; number: number } | null {
@@ -153,16 +179,7 @@ function parseLawIdFromUrl(url: string): { year: number; number: number } | null
   return { year, number };
 }
 
-function compareByLastmodDesc(a: LawEntry, b: LawEntry): number {
-  const aDate = a.lastmod ? Date.parse(a.lastmod) : 0;
-  const bDate = b.lastmod ? Date.parse(b.lastmod) : 0;
-
-  if (aDate !== bDate) return bDate - aDate;
-  if (a.year !== b.year) return b.year - a.year;
-  return b.number - a.number;
-}
-
-async function collectLawEntries(options: CLIOptions): Promise<LawEntry[]> {
+async function collectSitemapEntries(options: CLIOptions): Promise<SitemapEntry[]> {
   console.log('Fetching sitemap index...');
   const indexXml = await fetchText(SITEMAP_INDEX_URL);
   let sitemapPages = extractSitemapLocs(indexXml).filter(url => /sitemap\.xml\?page=\d+$/u.test(url));
@@ -173,45 +190,31 @@ async function collectLawEntries(options: CLIOptions): Promise<LawEntry[]> {
 
   console.log(`Sitemap pages to scan: ${sitemapPages.length}`);
 
-  const lawMap = new Map<string, LawEntry>();
+  const entries = new Map<string, SitemapEntry>();
 
   for (let i = 0; i < sitemapPages.length; i++) {
     const pageUrl = sitemapPages[i];
     console.log(`  [${i + 1}/${sitemapPages.length}] ${pageUrl}`);
 
+    await sleep(options.delayMs);
     const pageXml = await fetchText(pageUrl);
-    const entries = extractUrlEntries(pageXml);
 
-    for (const entry of entries) {
-      if (!isLtaUrl(entry.loc)) continue;
-
+    for (const entry of extractUrlEntries(pageXml)) {
       const parsed = parseLawIdFromUrl(entry.loc);
       if (!parsed) continue;
 
       if (options.yearStart && parsed.year < options.yearStart) continue;
       if (options.yearEnd && parsed.year > options.yearEnd) continue;
 
-      const existing = lawMap.get(entry.loc);
+      const id = `${parsed.year}_${parsed.number}`;
+      const existing = entries.get(id);
       if (!existing || ((entry.lastmod ?? '') > (existing.lastmod ?? ''))) {
-        lawMap.set(entry.loc, {
-          url: entry.loc,
-          year: parsed.year,
-          number: parsed.number,
-          lastmod: entry.lastmod,
-        });
+        entries.set(id, { id, url: entry.loc, lastmod: entry.lastmod ?? null });
       }
     }
-
-    await sleep(200);
   }
 
-  const laws = [...lawMap.values()].sort(compareByLastmodDesc);
-
-  if (options.limit && options.limit > 0) {
-    return laws.slice(0, options.limit);
-  }
-
-  return laws;
+  return [...entries.values()];
 }
 
 function getExistingSeedIds(): Set<string> {
@@ -228,114 +231,190 @@ function getExistingSeedIds(): Set<string> {
     const year = match[1];
     const number = Number.parseInt(match[2], 10);
     if (Number.isFinite(number) && number > 0) {
-      existing.add(`${year}:${number}`);
+      existing.add(`${year}_${number}`);
     }
   }
 
   return existing;
 }
 
+function readSeedMeta(id: string): SeedIngestMeta | null {
+  const seedPath = path.join(OUTPUT_DIR, `${id}.json`);
+  try {
+    const seed = JSON.parse(fs.readFileSync(seedPath, 'utf-8')) as { _ingest?: SeedIngestMeta };
+    return seed._ingest ?? null;
+  } catch {
+    // Unreadable seed == unstamped seed: it self-heals via refetch_unknown.
+    return null;
+  }
+}
+
 async function sleep(ms: number): Promise<void> {
   return new Promise(resolve => setTimeout(resolve, ms));
 }
 
-async function ingestBatch(
-  laws: LawEntry[],
+interface DecidedItem extends WorkItem {
+  decision: ReturnType<typeof decideFetch>;
+}
+
+async function processWorklist(
+  work: DecidedItem[],
   options: CLIOptions,
-  existingIds: Set<string>,
-): Promise<IngestionStats> {
-  const stats: IngestionStats = {
-    total: laws.length,
+): Promise<RunStats> {
+  const stats: RunStats = {
+    total: work.length,
+    fetched: 0,
     skipped: 0,
-    succeeded: 0,
-    failed: 0,
-    errors: [],
+    failed: [],
+    goneUpstream: [],
   };
 
   fs.mkdirSync(OUTPUT_DIR, { recursive: true });
 
-  for (let i = 0; i < laws.length; i++) {
-    const law = laws[i];
-    const id = `${law.year}:${law.number}`;
+  for (let i = 0; i < work.length; i++) {
+    const item = work[i];
+    const tag = `[${i + 1}/${work.length}] ${item.id}`;
 
-    if (options.skipExisting && existingIds.has(id)) {
-      console.log(`[${i + 1}/${laws.length}] SKIP ${id} (seed exists)`);
-      stats.skipped++;
+    if (item.decision === 'skip_existing' || item.decision === 'skip_current') {
+      stats.skipped += 1;
       continue;
     }
-
-    const outputPath = path.join(OUTPUT_DIR, `${law.year}_${law.number}.json`);
-    const xmlUrl = `${law.url}/xml`;
 
     if (options.dryRun) {
-      console.log(`[${i + 1}/${laws.length}] DRY RUN ${id} <- ${xmlUrl}`);
-      stats.succeeded++;
+      console.log(`${tag} DRY RUN ${item.decision} <- ${item.xmlUrl}`);
+      stats.fetched += 1;
       continue;
     }
 
-    try {
-      await ingest(xmlUrl, outputPath);
-      console.log(`[${i + 1}/${laws.length}] OK ${id}`);
-      stats.succeeded++;
-      existingIds.add(id);
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      console.error(`[${i + 1}/${laws.length}] FAIL ${id}: ${message}`);
-      stats.failed++;
-      stats.errors.push({ id, error: message });
-    }
+    const outputPath = path.join(OUTPUT_DIR, `${item.id}.json`);
 
-    if (options.delayMs > 0) {
-      await sleep(options.delayMs);
+    await sleep(options.delayMs);
+    try {
+      const result = await ingest(item.xmlUrl, outputPath);
+      const expectedId = item.id.replace('_', ':');
+      if (result.seedId !== expectedId) {
+        // The URL served a document with a different identity than the URL
+        // claims — record loudly instead of leaving the held seed stale.
+        stats.failed.push({
+          id: item.id,
+          error: `identity mismatch: URL ${item.xmlUrl} served document ${result.seedId}`,
+        });
+        console.error(`${tag} FAIL identity mismatch: served ${result.seedId}`);
+        continue;
+      }
+      console.log(`${tag} OK ${item.decision} status=${result.status}`);
+      stats.fetched += 1;
+    } catch (error) {
+      if (error instanceof GoneUpstreamError) {
+        stats.goneUpstream.push({ id: item.id, httpStatus: error.httpStatus });
+        console.error(`${tag} GONE upstream (HTTP ${error.httpStatus}) — seed kept`);
+        continue;
+      }
+      const message = error instanceof Error ? error.message : String(error);
+      stats.failed.push({ id: item.id, error: message });
+      console.error(`${tag} FAIL ${message}`);
     }
   }
 
   return stats;
 }
 
-function printSummary(stats: IngestionStats, options: CLIOptions): void {
-  console.log('\n' + '='.repeat(72));
-  console.log('DANISH BULK INGEST SUMMARY');
-  console.log('='.repeat(72));
-  console.log(`Total candidates:        ${stats.total}`);
-  console.log(`Skipped existing:        ${stats.skipped}`);
-  console.log(`Ingested successfully:   ${stats.succeeded}`);
-  console.log(`Failed:                  ${stats.failed}`);
-  console.log(`Dry run:                 ${options.dryRun ? 'YES' : 'NO'}`);
-  console.log('='.repeat(72));
-
-  if (stats.errors.length > 0) {
-    console.log('\nFailed items (first 50):');
-    for (const { id, error } of stats.errors.slice(0, 50)) {
-      console.log(`  - ${id}: ${error}`);
-    }
-  }
-}
-
 async function run(): Promise<void> {
   const options = parseArgs();
+  const runStartedAt = new Date().toISOString();
+  const today = runStartedAt.slice(0, 10);
 
   console.log('Automated Danish Law Ingestion');
   console.log('===============================\n');
+  console.log(`Run started: ${runStartedAt}`);
+  console.log(`Mode: ${options.refresh ? 'REFRESH (version-keyed)' : 'additive'}`);
   console.log(`Year range: ${options.yearStart ?? 'all'} -> ${options.yearEnd ?? 'all'}`);
   console.log(`Limit: ${options.limit ?? 'none'}`);
-  console.log(`Max pages: ${options.maxPages ?? 'all'}`);
-  console.log(`Skip existing: ${options.skipExisting ? 'YES' : 'NO'}`);
+  console.log(`Skip stamped since: ${options.skipStampedSince ?? 'n/a'}`);
   console.log(`Dry run: ${options.dryRun ? 'YES' : 'NO'}`);
   console.log(`Delay per request: ${options.delayMs} ms\n`);
 
-  const laws = await collectLawEntries(options);
-  console.log(`\nLaw URLs selected: ${laws.length}`);
+  const sitemapEntries = await collectSitemapEntries(options);
+  console.log(`\nSitemap documents: ${sitemapEntries.length}`);
 
-  const existing = getExistingSeedIds();
-  console.log(`Existing statute seed files: ${existing.size}\n`);
+  const existingIds = getExistingSeedIds();
+  console.log(`Existing statute seed files: ${existingIds.size}`);
 
-  const stats = await ingestBatch(laws, options, existing);
-  printSummary(stats, options);
+  let worklist = buildWorklist({ sitemapEntries, existingSeedIds: existingIds });
 
-  if (!options.dryRun && stats.succeeded > 0) {
+  if (options.yearStart || options.yearEnd) {
+    worklist = worklist.filter(item => {
+      const year = Number.parseInt(item.id.slice(0, 4), 10);
+      if (options.yearStart && year < options.yearStart) return false;
+      if (options.yearEnd && year > options.yearEnd) return false;
+      return true;
+    });
+  }
+
+  const decided: DecidedItem[] = worklist.map(item => ({
+    ...item,
+    decision: decideFetch({
+      seedExists: item.seedExists,
+      refresh: options.refresh,
+      existingMeta: item.seedExists ? readSeedMeta(item.id) : null,
+      skipStampedSince: options.skipStampedSince ?? null,
+      today,
+    }),
+  }));
+
+  // Deterministic order: new documents (fetch_new) first — they are current
+  // law missing from the corpus, the most dangerous gap — then by id so an
+  // interrupted run + --skip-stamped-since resume converges.
+  const rank = (d: DecidedItem): number => (d.decision === 'fetch_new' ? 0 : 1);
+  decided.sort((a, b) => rank(a) - rank(b) || a.id.localeCompare(b.id));
+
+  let queue = decided;
+  if (options.limit && options.limit > 0) {
+    queue = decided.slice(0, options.limit);
+  }
+
+  const byDecision = new Map<string, number>();
+  for (const item of queue) {
+    byDecision.set(item.decision, (byDecision.get(item.decision) ?? 0) + 1);
+  }
+  console.log(`Worklist: ${queue.length} documents — ${[...byDecision.entries()].map(([k, v]) => `${k}=${v}`).join(', ')}\n`);
+
+  const stats = await processWorklist(queue, options);
+  const summary = summarizeRun(stats);
+
+  console.log('\n' + '='.repeat(72));
+  console.log('DANISH BULK INGEST SUMMARY');
+  console.log('='.repeat(72));
+  for (const line of summary.lines) console.log(line);
+  console.log('='.repeat(72));
+
+  const reportPath = options.reportPath
+    ?? path.join(REPORT_DIR, `ingest-refresh-${runStartedAt.slice(0, 10)}.json`);
+  fs.mkdirSync(path.dirname(reportPath), { recursive: true });
+  fs.writeFileSync(
+    reportPath,
+    `${JSON.stringify(
+      {
+        run_started_at: runStartedAt,
+        finished_at: new Date().toISOString(),
+        mode: options.refresh ? 'refresh' : 'additive',
+        options: { ...options },
+        decisions: Object.fromEntries(byDecision),
+        stats,
+        exit_code: summary.exitCode,
+      },
+      null,
+      2,
+    )}\n`,
+    'utf-8',
+  );
+  console.log(`Report written: ${reportPath}`);
+
+  if (!options.dryRun && stats.fetched > 0) {
     console.log('\nNext step: npm run build:db');
   }
+
+  process.exit(summary.exitCode);
 }
 
 run().catch(error => {

--- a/scripts/auto-ingest-all-statutes.ts
+++ b/scripts/auto-ingest-all-statutes.ts
@@ -1,11 +1,11 @@
 #!/usr/bin/env tsx
 /**
  * Automated bulk ingestion + corpus refresh for Danish laws from
- * Retsinformation (issue #89).
+ * Retsinformation (issue #89; hardened in PR #90 round 2).
  *
  * Source flow:
  *   sitemap.xml -> /eli/lta/{year}/{number} URLs (UNION with held seeds)
- *   -> /xml payload -> stamped seed JSON
+ *   -> /xml payload -> identity-checked, atomically written, stamped seed
  *
  * Modes:
  *   default      additive: only documents without a seed are fetched
@@ -16,12 +16,22 @@
  * Fail-loud contract:
  *   - transient fetch failures retry with backoff, then count as FAILED —
  *     never as "document gone"; the run continues and exits 2 at the end.
- *   - HTTP 404/410 is positive gone-evidence: enumerated in the report,
- *     seed kept, exit code unaffected.
- *   - every failed/gone document is enumerated in the JSON report.
+ *   - HTTP 404/410 is positive gone-evidence: the held seed is QUARANTINED
+ *     to data/seed-gone/ (rename, never delete — it must not keep flowing
+ *     into builds as current law), enumerated in the report, exit code
+ *     unaffected.
+ *   - identity gate: a held seed is refetched ONLY under its own held id —
+ *     ingest() refuses (no write) if the URL serves a different document.
+ *   - a sitemap yielding zero pages or zero entries FAILS the run instead
+ *     of degrading to a seeds-only sweep.
+ *   - every failed/gone document is enumerated in the run-stamped JSON
+ *     report; a run-start MARKER file is written at startup and a partial
+ *     report is written on SIGINT/SIGTERM, so an interrupted run's
+ *     --skip-stamped-since cutoff is always recoverable.
  *
- * Politeness: >= 2s start-to-start pacing against retsinformation.dk; one
- * request in flight at a time.
+ * Politeness: >= 2s start-to-start pacing against retsinformation.dk
+ * INCLUDING retries; one request in flight at a time. Enforced for
+ * --dry-run too (dry runs still fetch live sitemap pages).
  *
  * Usage:
  *   node --import tsx scripts/auto-ingest-all-statutes.ts
@@ -30,99 +40,46 @@
  *     --skip-stamped-since 2026-06-11T00:00:00Z   # resume interrupted run
  *   node --import tsx scripts/auto-ingest-all-statutes.ts --limit 500 --dry-run
  *
- * Exit codes: 0 = complete; 1 = fatal; 2 = partial (failures enumerated).
+ * Exit codes: 0 = complete; 1 = fatal; 2 = partial (failures enumerated);
+ * 130/143 = interrupted (SIGINT/SIGTERM, partial report written).
  */
 
 import * as fs from 'fs';
 import * as path from 'path';
-import { fileURLToPath } from 'url';
+import { fileURLToPath, pathToFileURL } from 'url';
 import { ingest, GoneUpstreamError } from './ingest-retsinformation.js';
 import { decideFetch, type SeedIngestMeta } from './lib/refresh-policy.js';
-import { buildWorklist, summarizeRun, type SitemapEntry, type WorkItem, type RunStats } from './lib/refresh-worklist.js';
+import {
+  applyLimit,
+  buildWorklist,
+  quarantineGoneSeed,
+  readHeldSeedId,
+  summarizeRun,
+  type WorkItem,
+  type RunStats,
+} from './lib/refresh-worklist.js';
 import { fetchWithRetry } from './lib/http-retry.js';
+import { parseRefreshArgs, REQUEST_DELAY_MS, type CLIOptions } from './lib/refresh-cli.js';
+import { collectSitemapEntries } from './lib/sitemap.js';
+import {
+  buildReportPath,
+  makeInterruptHandler,
+  writeReport,
+  writeRunMarker,
+} from './lib/run-report.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
 const SITEMAP_INDEX_URL = 'https://www.retsinformation.dk/sitemap.xml';
 const OUTPUT_DIR = path.resolve(__dirname, '../data/seed');
+const QUARANTINE_DIR = path.resolve(__dirname, '../data/seed-gone');
 const REPORT_DIR = path.resolve(__dirname, '../reports');
-/** Politeness floor for retsinformation.dk: 2s start-to-start, sequential. */
-const REQUEST_DELAY_MS = 2_000;
 const USER_AGENT = 'Danish-Law-MCP/1.0.0 (bulk-ingest)';
-
-interface CLIOptions {
-  limit?: number;
-  yearStart?: number;
-  yearEnd?: number;
-  dryRun: boolean;
-  refresh: boolean;
-  skipStampedSince?: string;
-  maxPages?: number;
-  delayMs: number;
-  reportPath?: string;
-}
-
-function parseArgs(): CLIOptions {
-  const args = process.argv.slice(2);
-  const options: CLIOptions = {
-    dryRun: false,
-    refresh: false,
-    delayMs: REQUEST_DELAY_MS,
-  };
-
-  for (let i = 0; i < args.length; i++) {
-    const arg = args[i];
-
-    switch (arg) {
-      case '--limit':
-        options.limit = Number.parseInt(args[++i], 10);
-        break;
-      case '--year-start':
-        options.yearStart = Number.parseInt(args[++i], 10);
-        break;
-      case '--year-end':
-        options.yearEnd = Number.parseInt(args[++i], 10);
-        break;
-      case '--max-pages':
-        options.maxPages = Number.parseInt(args[++i], 10);
-        break;
-      case '--delay-ms':
-        options.delayMs = Number.parseInt(args[++i], 10);
-        break;
-      case '--dry-run':
-        options.dryRun = true;
-        break;
-      case '--refresh':
-        options.refresh = true;
-        break;
-      case '--skip-stamped-since':
-        options.skipStampedSince = args[++i];
-        break;
-      case '--report':
-        options.reportPath = args[++i];
-        break;
-      case '--no-skip':
-        // Legacy alias: a full refetch regardless of stamps is --refresh
-        // without --skip-stamped-since.
-        options.refresh = true;
-        break;
-      default:
-        throw new Error(`Unknown argument: ${arg}`);
-    }
-  }
-
-  if (options.delayMs < REQUEST_DELAY_MS && !options.dryRun) {
-    throw new Error(
-      `--delay-ms ${options.delayMs} is below the ${REQUEST_DELAY_MS}ms politeness floor for retsinformation.dk`,
-    );
-  }
-
-  return options;
-}
 
 async function fetchText(url: string): Promise<string> {
   const response = await fetchWithRetry(url, {
+    minDelayMs: REQUEST_DELAY_MS,
     headers: {
       Accept: 'application/xml,text/xml,*/*',
       'User-Agent': USER_AGENT,
@@ -136,85 +93,14 @@ async function fetchText(url: string): Promise<string> {
   return response.text();
 }
 
-function extractSitemapLocs(xml: string): string[] {
-  const locs: string[] = [];
-  const pattern = /<loc>([^<]+)<\/loc>/g;
-
-  for (const match of xml.matchAll(pattern)) {
-    const url = match[1]?.trim();
-    if (url) locs.push(url);
-  }
-
-  return locs;
-}
-
-function extractUrlEntries(xml: string): Array<{ loc: string; lastmod?: string }> {
-  const entries: Array<{ loc: string; lastmod?: string }> = [];
-  const pattern = /<url>\s*<loc>([^<]+)<\/loc>\s*(?:<lastmod>([^<]+)<\/lastmod>)?\s*<\/url>/g;
-
-  for (const match of xml.matchAll(pattern)) {
-    const loc = match[1]?.trim();
-    if (!loc) continue;
-
-    entries.push({
-      loc,
-      lastmod: match[2]?.trim(),
-    });
-  }
-
-  return entries;
-}
-
-function parseLawIdFromUrl(url: string): { year: number; number: number } | null {
-  const match = url.match(/\/eli\/lta\/(\d{4})\/(\d+)$/u);
-  if (!match) return null;
-
-  const year = Number.parseInt(match[1], 10);
-  const number = Number.parseInt(match[2], 10);
-
-  if (!Number.isFinite(year) || !Number.isFinite(number)) {
+function readSeedMeta(seedPath: string): SeedIngestMeta | null {
+  try {
+    const seed = JSON.parse(fs.readFileSync(seedPath, 'utf-8')) as { _ingest?: SeedIngestMeta };
+    return seed._ingest ?? null;
+  } catch {
+    // Unreadable seed == unstamped seed: it self-heals via refetch_unknown.
     return null;
   }
-
-  return { year, number };
-}
-
-async function collectSitemapEntries(options: CLIOptions): Promise<SitemapEntry[]> {
-  console.log('Fetching sitemap index...');
-  const indexXml = await fetchText(SITEMAP_INDEX_URL);
-  let sitemapPages = extractSitemapLocs(indexXml).filter(url => /sitemap\.xml\?page=\d+$/u.test(url));
-
-  if (options.maxPages && options.maxPages > 0) {
-    sitemapPages = sitemapPages.slice(0, options.maxPages);
-  }
-
-  console.log(`Sitemap pages to scan: ${sitemapPages.length}`);
-
-  const entries = new Map<string, SitemapEntry>();
-
-  for (let i = 0; i < sitemapPages.length; i++) {
-    const pageUrl = sitemapPages[i];
-    console.log(`  [${i + 1}/${sitemapPages.length}] ${pageUrl}`);
-
-    await sleep(options.delayMs);
-    const pageXml = await fetchText(pageUrl);
-
-    for (const entry of extractUrlEntries(pageXml)) {
-      const parsed = parseLawIdFromUrl(entry.loc);
-      if (!parsed) continue;
-
-      if (options.yearStart && parsed.year < options.yearStart) continue;
-      if (options.yearEnd && parsed.year > options.yearEnd) continue;
-
-      const id = `${parsed.year}_${parsed.number}`;
-      const existing = entries.get(id);
-      if (!existing || ((entry.lastmod ?? '') > (existing.lastmod ?? ''))) {
-        entries.set(id, { id, url: entry.loc, lastmod: entry.lastmod ?? null });
-      }
-    }
-  }
-
-  return [...entries.values()];
 }
 
 function getExistingSeedIds(): Set<string> {
@@ -238,38 +124,34 @@ function getExistingSeedIds(): Set<string> {
   return existing;
 }
 
-function readSeedMeta(id: string): SeedIngestMeta | null {
-  const seedPath = path.join(OUTPUT_DIR, `${id}.json`);
-  try {
-    const seed = JSON.parse(fs.readFileSync(seedPath, 'utf-8')) as { _ingest?: SeedIngestMeta };
-    return seed._ingest ?? null;
-  } catch {
-    // Unreadable seed == unstamped seed: it self-heals via refetch_unknown.
-    return null;
-  }
-}
-
 async function sleep(ms: number): Promise<void> {
   return new Promise(resolve => setTimeout(resolve, ms));
 }
 
-interface DecidedItem extends WorkItem {
+export interface DecidedItem extends WorkItem {
   decision: ReturnType<typeof decideFetch>;
 }
 
-async function processWorklist(
-  work: DecidedItem[],
-  options: CLIOptions,
-): Promise<RunStats> {
-  const stats: RunStats = {
-    total: work.length,
-    fetched: 0,
-    skipped: 0,
-    failed: [],
-    goneUpstream: [],
-  };
+export interface ProcessDeps {
+  ingestFn?: typeof ingest;
+  seedDir?: string;
+  quarantineDir?: string;
+  sleepFn?: (ms: number) => Promise<void>;
+}
 
-  fs.mkdirSync(OUTPUT_DIR, { recursive: true });
+export async function processWorklist(
+  work: DecidedItem[],
+  options: Pick<CLIOptions, 'dryRun' | 'delayMs'>,
+  stats: RunStats,
+  deps: ProcessDeps = {},
+): Promise<void> {
+  const ingestFn = deps.ingestFn ?? ingest;
+  const seedDir = deps.seedDir ?? OUTPUT_DIR;
+  const quarantineDir = deps.quarantineDir ?? QUARANTINE_DIR;
+  const sleepFn = deps.sleepFn ?? sleep;
+
+  stats.total = work.length;
+  fs.mkdirSync(seedDir, { recursive: true });
 
   for (let i = 0; i < work.length; i++) {
     const item = work[i];
@@ -286,41 +168,53 @@ async function processWorklist(
       continue;
     }
 
-    const outputPath = path.join(OUTPUT_DIR, `${item.id}.json`);
+    const outputPath = path.join(seedDir, `${item.id}.json`);
 
-    await sleep(options.delayMs);
+    // Identity gate expectation: the identity we ALREADY SERVE (the held
+    // seed's id) — never a re-derived format. Pre-1901 statutes legitimately
+    // carry DocumentId-fallback ids (AL000501, CM016392, ...): those are the
+    // prod-stable citation identity and must keep matching. A never-held or
+    // unreadable seed has no held identity: the served id IS the identity.
+    const heldId = item.seedExists ? readHeldSeedId(outputPath) : null;
+
+    await sleepFn(options.delayMs);
     try {
-      const result = await ingest(item.xmlUrl, outputPath);
-      const expectedId = item.id.replace('_', ':');
-      if (result.seedId !== expectedId) {
-        // The URL served a document with a different identity than the URL
-        // claims — record loudly instead of leaving the held seed stale.
-        stats.failed.push({
-          id: item.id,
-          error: `identity mismatch: URL ${item.xmlUrl} served document ${result.seedId}`,
-        });
-        console.error(`${tag} FAIL identity mismatch: served ${result.seedId}`);
-        continue;
-      }
+      const result = await ingestFn(
+        item.xmlUrl,
+        outputPath,
+        heldId !== null ? { expectedId: heldId } : {},
+      );
       console.log(`${tag} OK ${item.decision} status=${result.status}`);
       stats.fetched += 1;
     } catch (error) {
       if (error instanceof GoneUpstreamError) {
-        stats.goneUpstream.push({ id: item.id, httpStatus: error.httpStatus });
-        console.error(`${tag} GONE upstream (HTTP ${error.httpStatus}) — seed kept`);
+        const quarantinedPath = quarantineGoneSeed(outputPath, quarantineDir);
+        stats.goneUpstream.push({
+          id: item.id,
+          httpStatus: error.httpStatus,
+          quarantined: quarantinedPath !== null,
+        });
+        console.error(
+          `${tag} GONE upstream (HTTP ${error.httpStatus})${
+            quarantinedPath !== null
+              ? ` — seed quarantined to ${path.relative(path.dirname(seedDir), quarantinedPath)}`
+              : ' — no held seed'
+          }`,
+        );
         continue;
       }
+      // IdentityMismatchError lands here too: ingest() refused BEFORE any
+      // write, the held seed is untouched, and the message says exactly
+      // which document the URL served.
       const message = error instanceof Error ? error.message : String(error);
       stats.failed.push({ id: item.id, error: message });
       console.error(`${tag} FAIL ${message}`);
     }
   }
-
-  return stats;
 }
 
 async function run(): Promise<void> {
-  const options = parseArgs();
+  const options = parseRefreshArgs(process.argv.slice(2));
   const runStartedAt = new Date().toISOString();
   const today = runStartedAt.slice(0, 10);
 
@@ -334,7 +228,44 @@ async function run(): Promise<void> {
   console.log(`Dry run: ${options.dryRun ? 'YES' : 'NO'}`);
   console.log(`Delay per request: ${options.delayMs} ms\n`);
 
-  const sitemapEntries = await collectSitemapEntries(options);
+  const reportPath = buildReportPath(REPORT_DIR, runStartedAt, options.reportPath);
+
+  // Durable run-start marker: if this run dies without a report, the exact
+  // resume cutoff is recovered from here, not from a maybe-redirected stdout.
+  const markerPath = writeRunMarker(REPORT_DIR, {
+    run_started_at: runStartedAt,
+    mode: options.refresh ? 'refresh' : 'additive',
+    skip_stamped_since: options.skipStampedSince ?? null,
+    report_path: reportPath,
+    resume_command: `--refresh --skip-stamped-since ${runStartedAt}`,
+  });
+  console.log(`Run marker written: ${markerPath}`);
+
+  const stats: RunStats = { total: 0, fetched: 0, skipped: 0, failed: [], goneUpstream: [] };
+  let byDecision = new Map<string, number>();
+
+  const buildPayload = (extra: Record<string, unknown> = {}): Record<string, unknown> => ({
+    run_started_at: runStartedAt,
+    finished_at: new Date().toISOString(),
+    mode: options.refresh ? 'refresh' : 'additive',
+    options: { ...options },
+    decisions: Object.fromEntries(byDecision),
+    stats,
+    ...extra,
+  });
+
+  const onInterrupt = makeInterruptHandler({ reportPath, payload: () => buildPayload() });
+  process.once('SIGINT', () => onInterrupt('SIGINT'));
+  process.once('SIGTERM', () => onInterrupt('SIGTERM'));
+
+  const sitemapEntries = await collectSitemapEntries({
+    indexUrl: SITEMAP_INDEX_URL,
+    fetchText,
+    delayMs: options.delayMs,
+    maxPages: options.maxPages,
+    yearStart: options.yearStart,
+    yearEnd: options.yearEnd,
+  });
   console.log(`\nSitemap documents: ${sitemapEntries.length}`);
 
   const existingIds = getExistingSeedIds();
@@ -356,7 +287,7 @@ async function run(): Promise<void> {
     decision: decideFetch({
       seedExists: item.seedExists,
       refresh: options.refresh,
-      existingMeta: item.seedExists ? readSeedMeta(item.id) : null,
+      existingMeta: item.seedExists ? readSeedMeta(path.join(OUTPUT_DIR, `${item.id}.json`)) : null,
       skipStampedSince: options.skipStampedSince ?? null,
       today,
     }),
@@ -368,18 +299,17 @@ async function run(): Promise<void> {
   const rank = (d: DecidedItem): number => (d.decision === 'fetch_new' ? 0 : 1);
   decided.sort((a, b) => rank(a) - rank(b) || a.id.localeCompare(b.id));
 
-  let queue = decided;
-  if (options.limit && options.limit > 0) {
-    queue = decided.slice(0, options.limit);
-  }
+  // --limit budgets only items that actually fetch: skips pass through free
+  // so chunked resumes advance instead of reprocessing the stamped prefix.
+  const queue = applyLimit(decided, options.limit);
 
-  const byDecision = new Map<string, number>();
+  byDecision = new Map<string, number>();
   for (const item of queue) {
     byDecision.set(item.decision, (byDecision.get(item.decision) ?? 0) + 1);
   }
   console.log(`Worklist: ${queue.length} documents — ${[...byDecision.entries()].map(([k, v]) => `${k}=${v}`).join(', ')}\n`);
 
-  const stats = await processWorklist(queue, options);
+  await processWorklist(queue, options, stats);
   const summary = summarizeRun(stats);
 
   console.log('\n' + '='.repeat(72));
@@ -388,26 +318,7 @@ async function run(): Promise<void> {
   for (const line of summary.lines) console.log(line);
   console.log('='.repeat(72));
 
-  const reportPath = options.reportPath
-    ?? path.join(REPORT_DIR, `ingest-refresh-${runStartedAt.slice(0, 10)}.json`);
-  fs.mkdirSync(path.dirname(reportPath), { recursive: true });
-  fs.writeFileSync(
-    reportPath,
-    `${JSON.stringify(
-      {
-        run_started_at: runStartedAt,
-        finished_at: new Date().toISOString(),
-        mode: options.refresh ? 'refresh' : 'additive',
-        options: { ...options },
-        decisions: Object.fromEntries(byDecision),
-        stats,
-        exit_code: summary.exitCode,
-      },
-      null,
-      2,
-    )}\n`,
-    'utf-8',
-  );
+  writeReport(reportPath, buildPayload({ exit_code: summary.exitCode }));
   console.log(`Report written: ${reportPath}`);
 
   if (!options.dryRun && stats.fetched > 0) {
@@ -417,7 +328,15 @@ async function run(): Promise<void> {
   process.exit(summary.exitCode);
 }
 
-run().catch(error => {
-  console.error('Fatal error:', error instanceof Error ? error.message : String(error));
-  process.exit(1);
-});
+const isDirectRun = (() => {
+  const scriptArg = process.argv[1];
+  if (!scriptArg) return false;
+  return pathToFileURL(path.resolve(scriptArg)).href === import.meta.url;
+})();
+
+if (isDirectRun) {
+  run().catch(error => {
+    console.error('Fatal error:', error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  });
+}

--- a/scripts/auto-ingest-all-statutes.ts
+++ b/scripts/auto-ingest-all-statutes.ts
@@ -176,14 +176,36 @@ export async function processWorklist(
     // prod-stable citation identity and must keep matching. A never-held or
     // unreadable seed has no held identity: the served id IS the identity.
     const heldId = item.seedExists ? readHeldSeedId(outputPath) : null;
+    // No held identity (fetch_new / torn seed): the URL-derived year:number
+    // is a shape-conditional expectation — enforced inside ingest() whenever
+    // the served id is year:number-shaped, so a redirect to a different
+    // modern document can never land under this item's filename (round 3).
+    const gateOpts =
+      heldId !== null ? { expectedId: heldId } : { urlDerivedId: item.id.replace('_', ':') };
 
     await sleepFn(options.delayMs);
     try {
-      const result = await ingestFn(
-        item.xmlUrl,
-        outputPath,
-        heldId !== null ? { expectedId: heldId } : {},
-      );
+      let result;
+      try {
+        result = await ingestFn(item.xmlUrl, outputPath, gateOpts);
+      } catch (error) {
+        // Quarantine removes law from the served corpus — that demands
+        // removal-grade evidence, not one unretried 404 (round 3):
+        //  - the sitemap LISTING the document contradicts "gone" outright;
+        //  - otherwise a single 404 gets one confirming probe after the
+        //    politeness delay; only a second 404 is gone-evidence.
+        if (error instanceof GoneUpstreamError && item.inSitemap) {
+          throw new Error(
+            `HTTP ${error.httpStatus} but the sitemap lists this document — contradictory evidence, treating as failure, seed kept`,
+          );
+        }
+        if (error instanceof GoneUpstreamError) {
+          await sleepFn(options.delayMs);
+          result = await ingestFn(item.xmlUrl, outputPath, gateOpts);
+        } else {
+          throw error;
+        }
+      }
       console.log(`${tag} OK ${item.decision} status=${result.status}`);
       stats.fetched += 1;
     } catch (error) {
@@ -195,7 +217,7 @@ export async function processWorklist(
           quarantined: quarantinedPath !== null,
         });
         console.error(
-          `${tag} GONE upstream (HTTP ${error.httpStatus})${
+          `${tag} GONE upstream (HTTP ${error.httpStatus}, confirmed by second probe)${
             quarantinedPath !== null
               ? ` — seed quarantined to ${path.relative(path.dirname(seedDir), quarantinedPath)}`
               : ' — no held seed'

--- a/scripts/ingest-relevant-laws.ts
+++ b/scripts/ingest-relevant-laws.ts
@@ -1,5 +1,25 @@
 #!/usr/bin/env tsx
 /**
+ * DEPRECATED 2026-06-11 (PR #90 round 2, Dutch-law-mcp FORCE_LEGACY_INGEST
+ * pattern): this is Swedish-template residue. It imports ingest() from
+ * ingest-riksdagen.js (Riksdagen API code with silent in_force defaulting
+ * and NO _ingest stamping) and writes slug-named seeds that the refresh
+ * worklist's ^(\d{4})_(\d+)\.json$ regex can never see — unstamped,
+ * silently-in_force seeds that build-db serves but no sweep can ever
+ * self-heal. Use `npm run ingest:auto-all` / scripts/ingest-retsinformation.ts.
+ */
+if (process.env.FORCE_LEGACY_INGEST !== '1') {
+  console.error(
+    'DEPRECATED: this script writes unstamped, slug-named seeds via the Swedish Riksdagen ' +
+      'template — invisible to the refresh worklist and silently defaulted to in_force. ' +
+      'Use `npm run ingest:auto-all` (scripts/auto-ingest-all-statutes.ts) or ' +
+      'scripts/ingest-retsinformation.ts instead. ' +
+      'Set FORCE_LEGACY_INGEST=1 only if you understand the staleness consequences.',
+  );
+  process.exit(2);
+}
+
+/**
  * Bulk-ingest a curated set of high-relevance Danish statutes.
  *
  * Usage:

--- a/scripts/ingest-retsinformation.ts
+++ b/scripts/ingest-retsinformation.ts
@@ -14,6 +14,43 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { fileURLToPath, pathToFileURL } from 'url';
 import { XMLParser } from 'fast-xml-parser';
+import {
+  extractVersionIdentity,
+  mapSeedStatus,
+  type VersionIdentity,
+  type SeedStatus,
+} from './lib/version-identity.js';
+import { stampIngestMeta, type SeedIngestMeta } from './lib/refresh-policy.js';
+import { fetchWithRetry } from './lib/http-retry.js';
+
+/**
+ * Positive evidence that the document is gone upstream (HTTP 404/410).
+ * Distinct from transient failures, which retry and then THROW a plain
+ * Error — a flaky network must never be classified as "document gone".
+ */
+export class GoneUpstreamError extends Error {
+  readonly httpStatus: number;
+  constructor(url: string, httpStatus: number) {
+    super(`document gone upstream: HTTP ${httpStatus} for ${url}`);
+    this.name = 'GoneUpstreamError';
+    this.httpStatus = httpStatus;
+  }
+}
+
+export interface IngestOptions {
+  fetchImpl?: typeof fetch;
+  /** ISO timestamp stamped as _ingest.retrieved_at; defaults to now. */
+  now?: string;
+  /** ISO 'YYYY-MM-DD' used for status date logic; defaults to today. */
+  today?: string;
+}
+
+export interface IngestResult {
+  seedId: string;
+  outputPath: string;
+  status: SeedStatus;
+  identity: VersionIdentity;
+}
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -155,18 +192,6 @@ function inferId(year: unknown, number: unknown, fallback: string): string {
   return fallback;
 }
 
-function inferStatus(rawStatus: unknown, startDate?: string, endDate?: string): SeedOutput['status'] {
-  const statusText = String(rawStatus ?? '').toLowerCase();
-  const today = new Date().toISOString().slice(0, 10);
-
-  if (startDate && startDate > today) return 'not_yet_in_force';
-  if (endDate && endDate < today) return 'repealed';
-  if (statusText.includes('valid') || statusText.includes('gældende')) return 'in_force';
-  if (statusText.includes('amend')) return 'amended';
-
-  return 'in_force';
-}
-
 function inferType(shortName: string): SeedOutput['type'] {
   const upper = shortName.toUpperCase();
 
@@ -184,8 +209,9 @@ function normalizeHref(href: string): string {
     .replace(/^https:\/\/retsinformation\.dk/i, 'https://www.retsinformation.dk');
 }
 
-async function fetchJson<T>(url: string): Promise<T> {
-  const response = await fetch(url, {
+async function fetchJson<T>(url: string, fetchImpl?: typeof fetch): Promise<T> {
+  const response = await fetchWithRetry(url, {
+    fetchImpl,
     headers: {
       Accept: 'application/json',
       'User-Agent': USER_AGENT,
@@ -199,14 +225,23 @@ async function fetchJson<T>(url: string): Promise<T> {
   return (await response.json()) as T;
 }
 
-async function fetchText(url: string): Promise<string> {
-  const response = await fetch(url, {
+/**
+ * Fetch a document XML payload. Transient failures retry and then THROW
+ * (plain Error); HTTP 404/410 raise GoneUpstreamError — the only statuses
+ * that count as positive gone-evidence.
+ */
+async function fetchDocumentXml(url: string, fetchImpl?: typeof fetch): Promise<string> {
+  const response = await fetchWithRetry(url, {
+    fetchImpl,
     headers: {
       Accept: 'application/xml,text/xml,*/*',
       'User-Agent': USER_AGENT,
     },
   });
 
+  if (response.status === 404 || response.status === 410) {
+    throw new GoneUpstreamError(url, response.status);
+  }
   if (!response.ok) {
     throw new Error(`HTTP ${response.status} for ${url}`);
   }
@@ -214,7 +249,7 @@ async function fetchText(url: string): Promise<string> {
   return response.text();
 }
 
-async function resolveDocument(identifier: string): Promise<RemoteDocument> {
+async function resolveDocument(identifier: string, fetchImpl?: typeof fetch): Promise<RemoteDocument> {
   if (/^https?:\/\//i.test(identifier)) {
     return {
       documentId: 'unknown',
@@ -226,7 +261,10 @@ async function resolveDocument(identifier: string): Promise<RemoteDocument> {
 
   // Try documentId endpoint first
   try {
-    return await fetchJson<RemoteDocument>(`${API_BASE}/Documents/${encodeURIComponent(identifier)}`);
+    return await fetchJson<RemoteDocument>(
+      `${API_BASE}/Documents/${encodeURIComponent(identifier)}`,
+      fetchImpl,
+    );
   } catch {
     // Fall through
   }
@@ -342,11 +380,18 @@ function buildDefaultOutputPath(seedId: string): string {
   return path.join(DEFAULT_SEED_DIR, `${toAsciiKey(seedId)}.json`);
 }
 
-export async function ingest(identifier: string, outputPath?: string): Promise<void> {
+export async function ingest(
+  identifier: string,
+  outputPath?: string,
+  opts: IngestOptions = {},
+): Promise<IngestResult> {
+  const now = opts.now ?? new Date().toISOString();
+  const today = opts.today ?? now.slice(0, 10);
+
   console.log('Retsinformation Ingestion');
   console.log(`  Identifier: ${identifier}`);
 
-  const remoteDoc = await resolveDocument(identifier);
+  const remoteDoc = await resolveDocument(identifier, opts.fetchImpl);
   const href = remoteDoc.href ? normalizeHref(remoteDoc.href) : undefined;
 
   if (!href) {
@@ -355,7 +400,7 @@ export async function ingest(identifier: string, outputPath?: string): Promise<v
 
   console.log(`  XML source: ${href}`);
 
-  const xml = await fetchText(href);
+  const xml = await fetchDocumentXml(href, opts.fetchImpl);
 
   const parser = new XMLParser({
     ignoreAttributes: false,
@@ -377,38 +422,57 @@ export async function ingest(identifier: string, outputPath?: string): Promise<v
   const title = normalizeWhitespace(extractText(meta.DocumentTitle)) || 'Untitled Retsinformation document';
   const shortName = normalizeWhitespace(extractText(meta.DocumentType));
   const issuedDate = parseIsoDate(meta.DiesSigni);
-  const startDate = parseIsoDate(meta.StartDate);
-  const endDate = parseIsoDate(meta.EndDate);
   const documentId = normalizeWhitespace(extractText(meta.DocumentId)) || remoteDoc.documentId || 'unknown';
-  const accession = normalizeWhitespace(extractText(meta.AccessionNumber)) || remoteDoc.accessionsnummer || identifier;
   const seedId = inferId(meta.Year, meta.Number, documentId);
+
+  // Version identity of the served consolidation (issue #89). Status mapping
+  // is explicit and THROWS on unknown vocabulary — no seed is written then.
+  const identity = extractVersionIdentity(meta);
+  if (!identity.document_id) identity.document_id = documentId;
+  if (!identity.accession && remoteDoc.accessionsnummer && remoteDoc.accessionsnummer !== identifier) {
+    identity.accession = remoteDoc.accessionsnummer;
+  }
+  const status = mapSeedStatus(identity, today);
+  const startDate = identity.start_date ?? undefined;
+  const endDate = identity.end_date ?? undefined;
+  const accession = identity.accession ?? identifier;
 
   const provisions = collectProvisions(documentNode);
   const definitions = extractDefinitions(provisions);
 
+  // valid_to only when validity actually ended (repealed): <EndDate> on a
+  // Valid document is the amended-through marker, not a validity end.
+  const validityEnd = status === 'repealed' ? identity.historic_marked ?? endDate ?? null : null;
+
   const provisionVersions = provisions.map((p): ProvisionVersionSeed => ({
     ...p,
     valid_from: startDate ?? issuedDate ?? null,
-    valid_to: endDate ?? null,
+    valid_to: validityEnd,
   }));
 
-  const seed: SeedOutput = {
+  // 'Ophævet <date>' is parsed by build-db.ts deriveDocumentValidityWindow
+  // to set the document validity end for superseded consolidations.
+  const repealNote = status === 'repealed' && validityEnd ? ` Ophævet ${validityEnd}.` : '';
+
+  const seedBody: SeedOutput = {
     id: seedId,
     type: inferType(shortName),
     title,
     title_en: undefined,
     short_name: shortName || undefined,
-    status: inferStatus(meta.Status, startDate, endDate),
+    status,
     issued_date: issuedDate,
     in_force_date: startDate,
     url: href,
     description: normalizeWhitespace(
-      `Retsinformation source. DocumentId=${documentId}; AccessionNumber=${accession}; Characters preserved in NFC; ASCII fallback used only for key/file generation.`,
+      `Retsinformation source. DocumentId=${documentId}; AccessionNumber=${accession};${repealNote} Characters preserved in NFC; ASCII fallback used only for key/file generation.`,
     ),
     provisions,
     provision_versions: provisionVersions,
     definitions,
   };
+
+  const seed: SeedOutput & { _ingest: SeedIngestMeta } = stampIngestMeta(seedBody, identity, status, now);
 
   const finalOutputPath = outputPath
     ? path.resolve(PROJECT_ROOT, outputPath)
@@ -419,7 +483,10 @@ export async function ingest(identifier: string, outputPath?: string): Promise<v
 
   console.log(`  Provisions extracted: ${seed.provisions.length}`);
   console.log(`  Definitions extracted: ${seed.definitions.length}`);
+  console.log(`  Status: ${status} (upstream: ${identity.upstream_status ?? 'n/a'}, end: ${identity.end_date ?? 'open'})`);
   console.log(`  Seed file written: ${path.relative(PROJECT_ROOT, finalOutputPath)}`);
+
+  return { seedId, outputPath: finalOutputPath, status, identity };
 }
 
 async function main(): Promise<void> {

--- a/scripts/ingest-retsinformation.ts
+++ b/scripts/ingest-retsinformation.ts
@@ -73,6 +73,13 @@ export interface IngestOptions {
    * On mismatch ingest() throws IdentityMismatchError before any write.
    */
   expectedId?: string;
+  /**
+   * Shape-conditional identity expectation for items with no held identity
+   * (fetch_new / unreadable seed): enforced only when the SERVED id is
+   * year:number-shaped. Pre-1901 documents legitimately serve
+   * DocumentId-fallback ids, which cannot be URL-verified — those pass.
+   */
+  urlDerivedId?: string;
 }
 
 export interface IngestResult {
@@ -465,6 +472,14 @@ export async function ingest(
   // as what it is, not as unknown vocabulary.
   if (opts.expectedId !== undefined && seedId !== opts.expectedId) {
     throw new IdentityMismatchError(href, seedId, opts.expectedId);
+  }
+  if (
+    opts.expectedId === undefined &&
+    opts.urlDerivedId !== undefined &&
+    /^\d{4}:\d+$/u.test(seedId) &&
+    seedId !== opts.urlDerivedId
+  ) {
+    throw new IdentityMismatchError(href, seedId, opts.urlDerivedId);
   }
 
   // Version identity of the served consolidation (issue #89). Status mapping

--- a/scripts/ingest-retsinformation.ts
+++ b/scripts/ingest-retsinformation.ts
@@ -16,12 +16,14 @@ import { fileURLToPath, pathToFileURL } from 'url';
 import { XMLParser } from 'fast-xml-parser';
 import {
   extractVersionIdentity,
+  isoDateOf,
   mapSeedStatus,
   type VersionIdentity,
   type SeedStatus,
 } from './lib/version-identity.js';
 import { stampIngestMeta, type SeedIngestMeta } from './lib/refresh-policy.js';
 import { fetchWithRetry } from './lib/http-retry.js';
+import { writeFileAtomic } from './lib/atomic-write.js';
 
 /**
  * Positive evidence that the document is gone upstream (HTTP 404/410).
@@ -37,12 +39,40 @@ export class GoneUpstreamError extends Error {
   }
 }
 
+/**
+ * The URL served a document with a different identity than the caller
+ * expected (PR #90 round 2). Raised BEFORE any seed write — a body for a
+ * different document must never be written under the held statute's identity
+ * (Dutch-law-mcp ingest-bwb.ts ordering). The expected identity is the HELD
+ * seed's id (what we already serve), never a re-derived format.
+ */
+export class IdentityMismatchError extends Error {
+  readonly url: string;
+  readonly servedId: string;
+  readonly expectedId: string;
+  constructor(url: string, servedId: string, expectedId: string) {
+    super(
+      `identity mismatch: URL ${url} served document "${servedId}" but the held identity is ` +
+        `"${expectedId}" — refusing to write a different document's body under this seed`,
+    );
+    this.name = 'IdentityMismatchError';
+    this.url = url;
+    this.servedId = servedId;
+    this.expectedId = expectedId;
+  }
+}
+
 export interface IngestOptions {
   fetchImpl?: typeof fetch;
   /** ISO timestamp stamped as _ingest.retrieved_at; defaults to now. */
   now?: string;
   /** ISO 'YYYY-MM-DD' used for status date logic; defaults to today. */
   today?: string;
+  /**
+   * The identity the caller expects the URL to serve (the held seed's id).
+   * On mismatch ingest() throws IdentityMismatchError before any write.
+   */
+  expectedId?: string;
 }
 
 export interface IngestResult {
@@ -59,6 +89,12 @@ const DEFAULT_SEED_DIR = path.join(PROJECT_ROOT, 'data', 'seed');
 
 const API_BASE = 'https://api.retsinformation.dk/v1';
 const USER_AGENT = 'Danish-Law-MCP/1.0.0 (https://github.com/Ansvar-Systems/Denmark-law-mcp)';
+/**
+ * Politeness floor for retsinformation.dk: >= 2s start-to-start INCLUDING
+ * retries (the default backoff ladder starts at 1s and would re-hit a
+ * throttling upstream too fast).
+ */
+const RETRY_PACING_FLOOR_MS = 2_000;
 
 interface RemoteDocument {
   documentId: string;
@@ -125,12 +161,6 @@ function toAsciiKey(input: string): string {
 function asArray<T>(value: T | T[] | undefined | null): T[] {
   if (value == null) return [];
   return Array.isArray(value) ? value : [value];
-}
-
-function parseIsoDate(value: unknown): string | undefined {
-  if (typeof value !== 'string') return undefined;
-  const match = value.match(/\d{4}-\d{2}-\d{2}/);
-  return match?.[0];
 }
 
 function extractText(node: unknown): string {
@@ -212,6 +242,7 @@ function normalizeHref(href: string): string {
 async function fetchJson<T>(url: string, fetchImpl?: typeof fetch): Promise<T> {
   const response = await fetchWithRetry(url, {
     fetchImpl,
+    minDelayMs: RETRY_PACING_FLOOR_MS,
     headers: {
       Accept: 'application/json',
       'User-Agent': USER_AGENT,
@@ -233,6 +264,7 @@ async function fetchJson<T>(url: string, fetchImpl?: typeof fetch): Promise<T> {
 async function fetchDocumentXml(url: string, fetchImpl?: typeof fetch): Promise<string> {
   const response = await fetchWithRetry(url, {
     fetchImpl,
+    minDelayMs: RETRY_PACING_FLOOR_MS,
     headers: {
       Accept: 'application/xml,text/xml,*/*',
       'User-Agent': USER_AGENT,
@@ -421,9 +453,19 @@ export async function ingest(
 
   const title = normalizeWhitespace(extractText(meta.DocumentTitle)) || 'Untitled Retsinformation document';
   const shortName = normalizeWhitespace(extractText(meta.DocumentType));
-  const issuedDate = parseIsoDate(meta.DiesSigni);
+  // Attribute-tolerant like every other date field: <DiesSigni REFid=...>
+  // parses to an object and the old string-only parser yielded undefined.
+  const issuedDate = isoDateOf(meta.DiesSigni) ?? undefined;
   const documentId = normalizeWhitespace(extractText(meta.DocumentId)) || remoteDoc.documentId || 'unknown';
   const seedId = inferId(meta.Year, meta.Number, documentId);
+
+  // Identity gate BEFORE anything else (PR #90 round 2): a body for a
+  // different document must never be written under the held statute's
+  // identity. Checked before status mapping so a redirect surprise reports
+  // as what it is, not as unknown vocabulary.
+  if (opts.expectedId !== undefined && seedId !== opts.expectedId) {
+    throw new IdentityMismatchError(href, seedId, opts.expectedId);
+  }
 
   // Version identity of the served consolidation (issue #89). Status mapping
   // is explicit and THROWS on unknown vocabulary — no seed is written then.
@@ -479,7 +521,9 @@ export async function ingest(
     : buildDefaultOutputPath(seedId);
 
   fs.mkdirSync(path.dirname(finalOutputPath), { recursive: true });
-  fs.writeFileSync(finalOutputPath, `${JSON.stringify(seed, null, 2)}\n`, 'utf-8');
+  // Atomic replace: a kill mid-write must never destroy the held good seed
+  // or leave torn JSON (PR #90 round 2).
+  writeFileAtomic(finalOutputPath, `${JSON.stringify(seed, null, 2)}\n`);
 
   console.log(`  Provisions extracted: ${seed.provisions.length}`);
   console.log(`  Definitions extracted: ${seed.definitions.length}`);

--- a/scripts/ingest-riksdagen.ts
+++ b/scripts/ingest-riksdagen.ts
@@ -440,6 +440,15 @@ export async function ingest(sfsNumber: string, outputPath: string): Promise<voi
 
 const isMainModule = process.argv[1] != null && pathToFileURL(process.argv[1]).href === import.meta.url;
 
+if (isMainModule && process.env.FORCE_LEGACY_INGEST !== '1') {
+  console.error(
+    'DEPRECATED (PR #90 round 3): this is the Swedish Riksdagen template ingester — it writes ' +
+      'unstamped seeds the Danish refresh worklist cannot see (issue #89 class). ' +
+      'Use npm run ingest (retsinformation) instead. Set FORCE_LEGACY_INGEST=1 only if you understand the consequences.',
+  );
+  process.exit(2);
+}
+
 if (isMainModule) {
   const args = process.argv.slice(2);
 

--- a/scripts/lib/atomic-write.ts
+++ b/scripts/lib/atomic-write.ts
@@ -1,0 +1,36 @@
+/**
+ * Crash-safe file replacement (PR #90 round 2).
+ *
+ * fs.writeFileSync opens the destination with O_TRUNC: a kill/reboot
+ * mid-write destroys the previous good content and leaves torn JSON. During
+ * a 63k-document sweep that torn seed survives forever on the GONE path and
+ * in additive mode, and build-db crashes on it.
+ *
+ * Pattern: write a sibling `<file>.tmp`, fsync, rename over the destination.
+ * rename(2) within one directory is atomic — readers observe either the old
+ * or the new content, never a truncated file. No directories are invented:
+ * a bad path fails loud.
+ */
+
+import * as fs from 'fs';
+
+export function writeFileAtomic(filePath: string, data: string): void {
+  const tmpPath = `${filePath}.tmp`;
+  try {
+    const fd = fs.openSync(tmpPath, 'w');
+    try {
+      fs.writeSync(fd, data);
+      fs.fsyncSync(fd);
+    } finally {
+      fs.closeSync(fd);
+    }
+    fs.renameSync(tmpPath, filePath);
+  } catch (error) {
+    try {
+      fs.unlinkSync(tmpPath);
+    } catch {
+      // Best-effort cleanup; the original error is what matters.
+    }
+    throw error;
+  }
+}

--- a/scripts/lib/atomic-write.ts
+++ b/scripts/lib/atomic-write.ts
@@ -15,7 +15,7 @@
 import * as fs from 'fs';
 
 export function writeFileAtomic(filePath: string, data: string): void {
-  const tmpPath = `${filePath}.tmp`;
+  const tmpPath = `${filePath}.${process.pid}.tmp`; // PID suffix: concurrent runs must not share a tmp file
   try {
     const fd = fs.openSync(tmpPath, 'w');
     try {

--- a/scripts/lib/http-retry.ts
+++ b/scripts/lib/http-retry.ts
@@ -21,11 +21,20 @@ export async function fetchWithRetry(
     attempts?: number;
     backoffMs?: number[];
     headers?: Record<string, string>;
+    /**
+     * Per-upstream politeness floor for the inter-attempt sleep (PR #90
+     * round 2): the default backoff ladder starts at 1s, which is UNDER the
+     * 2s start-to-start floor promised to retsinformation.dk — and re-hitting
+     * a 429 after 1s worsens throttling and burns the attempt budget.
+     * Every retry sleep becomes max(backoff slot, minDelayMs).
+     */
+    minDelayMs?: number;
   } = {},
 ): Promise<Response> {
   const fetchImpl = opts.fetchImpl ?? fetch;
   const attempts = opts.attempts ?? 4;
   const backoff = opts.backoffMs ?? DEFAULT_BACKOFF_MS;
+  const minDelayMs = opts.minDelayMs ?? 0;
   let lastProblem = 'unknown';
 
   for (let attempt = 1; attempt <= attempts; attempt++) {
@@ -41,7 +50,7 @@ export async function fetchWithRetry(
       lastProblem = err instanceof Error ? err.message : String(err);
     }
     if (attempt < attempts) {
-      await sleep(backoff[Math.min(attempt - 1, backoff.length - 1)] ?? 0);
+      await sleep(Math.max(backoff[Math.min(attempt - 1, backoff.length - 1)] ?? 0, minDelayMs));
     }
   }
   throw new Error(`fetch ${url} failed after ${attempts} attempts: ${lastProblem}`);

--- a/scripts/lib/http-retry.ts
+++ b/scripts/lib/http-retry.ts
@@ -1,0 +1,48 @@
+/**
+ * Shared HTTP retry helper (issue #89, ported from Dutch-law-mcp#117).
+ *
+ * Transient failures (5xx, 429, thrown network errors) retry with backoff and
+ * then THROW. They are never soft-failed to null or skipped, so a flaky
+ * network can never be recorded as "document gone upstream". Non-retryable
+ * client errors (404 and other 4xx) are returned for the caller to interpret:
+ * a 404 on a document fetch IS a finding, not an error.
+ */
+
+const DEFAULT_BACKOFF_MS = [1_000, 2_000, 4_000];
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export async function fetchWithRetry(
+  url: string,
+  opts: {
+    fetchImpl?: typeof fetch;
+    attempts?: number;
+    backoffMs?: number[];
+    headers?: Record<string, string>;
+  } = {},
+): Promise<Response> {
+  const fetchImpl = opts.fetchImpl ?? fetch;
+  const attempts = opts.attempts ?? 4;
+  const backoff = opts.backoffMs ?? DEFAULT_BACKOFF_MS;
+  let lastProblem = 'unknown';
+
+  for (let attempt = 1; attempt <= attempts; attempt++) {
+    try {
+      const res = await fetchImpl(url, { redirect: 'follow', headers: opts.headers });
+      if (res.ok) return res;
+      if (res.status >= 500 || res.status === 429) {
+        lastProblem = `HTTP ${res.status}`;
+      } else {
+        return res; // non-retryable 4xx: the caller decides what it means
+      }
+    } catch (err) {
+      lastProblem = err instanceof Error ? err.message : String(err);
+    }
+    if (attempt < attempts) {
+      await sleep(backoff[Math.min(attempt - 1, backoff.length - 1)] ?? 0);
+    }
+  }
+  throw new Error(`fetch ${url} failed after ${attempts} attempts: ${lastProblem}`);
+}

--- a/scripts/lib/refresh-cli.ts
+++ b/scripts/lib/refresh-cli.ts
@@ -32,12 +32,18 @@ function flagValue(name: string, args: string[], i: number): string {
   return raw;
 }
 
-function intFlag(name: string, args: string[], i: number): number {
+function intFlag(name: string, args: string[], i: number, opts: { min?: number } = {}): number {
   const raw = flagValue(name, args, i);
   // Number(), not parseInt(): '500abc' must fail loud, not truncate to 500.
   const n = Number(raw);
   if (!Number.isFinite(n) || !Number.isInteger(n)) {
     throw new Error(`${name} must be a finite integer, got "${raw}"`);
+  }
+  if (opts.min !== undefined && n < opts.min) {
+    // 0/negative silently DISABLED limits downstream (applyLimit/sitemap
+    // truncation treat <=0 as "none") while the banner printed the value —
+    // a positive minimum keeps "no limit" an explicit omission, never a typo.
+    throw new Error(`${name} must be a positive integer (>= ${opts.min}), got "${raw}"`);
   }
   return n;
 }
@@ -73,7 +79,7 @@ export function parseRefreshArgs(args: string[]): CLIOptions {
 
     switch (arg) {
       case '--limit':
-        options.limit = intFlag('--limit', args, i++);
+        options.limit = intFlag('--limit', args, i++, { min: 1 });
         break;
       case '--year-start':
         options.yearStart = intFlag('--year-start', args, i++);
@@ -82,7 +88,7 @@ export function parseRefreshArgs(args: string[]): CLIOptions {
         options.yearEnd = intFlag('--year-end', args, i++);
         break;
       case '--max-pages':
-        options.maxPages = intFlag('--max-pages', args, i++);
+        options.maxPages = intFlag('--max-pages', args, i++, { min: 1 });
         break;
       case '--delay-ms':
         options.delayMs = intFlag('--delay-ms', args, i++);

--- a/scripts/lib/refresh-cli.ts
+++ b/scripts/lib/refresh-cli.ts
@@ -1,0 +1,121 @@
+/**
+ * CLI parsing for the bulk refresh runner (PR #90 round 2).
+ *
+ * Every numeric flag is Number.isFinite-validated: Number.parseInt('abc') is
+ * NaN, `NaN < 2000` is false, and a typo'd --delay-ms silently disabled the
+ * politeness floor for a 63k-request sweep. --skip-stamped-since — the resume
+ * lever whose value decides what gets SKIPPED — must be full ISO-8601 UTC and
+ * is normalized to millisecond precision so the lexicographic compare against
+ * toISOString() stamps is exact. Unknown vocabulary fails loud.
+ */
+
+/** Politeness floor for retsinformation.dk: 2s start-to-start, sequential. */
+export const REQUEST_DELAY_MS = 2_000;
+
+export interface CLIOptions {
+  limit?: number;
+  yearStart?: number;
+  yearEnd?: number;
+  dryRun: boolean;
+  refresh: boolean;
+  skipStampedSince?: string;
+  maxPages?: number;
+  delayMs: number;
+  reportPath?: string;
+}
+
+function flagValue(name: string, args: string[], i: number): string {
+  const raw = args[i + 1];
+  if (raw === undefined || raw.startsWith('--')) {
+    throw new Error(`${name} requires a value (got ${raw === undefined ? 'nothing' : `"${raw}"`})`);
+  }
+  return raw;
+}
+
+function intFlag(name: string, args: string[], i: number): number {
+  const raw = flagValue(name, args, i);
+  // Number(), not parseInt(): '500abc' must fail loud, not truncate to 500.
+  const n = Number(raw);
+  if (!Number.isFinite(n) || !Number.isInteger(n)) {
+    throw new Error(`${name} must be a finite integer, got "${raw}"`);
+  }
+  return n;
+}
+
+const ISO_UTC_PATTERN = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d{1,3})?Z$/u;
+
+function isoUtcFlag(name: string, args: string[], i: number): string {
+  const raw = flagValue(name, args, i);
+  if (!ISO_UTC_PATTERN.test(raw)) {
+    throw new Error(
+      `${name} must be full ISO-8601 UTC, e.g. 2026-06-10T20:22:27Z or 2026-06-10T20:22:27.792Z — got "${raw}". ` +
+        'Date-only or offset-bearing values silently shift the skip boundary.',
+    );
+  }
+  const parsed = Date.parse(raw);
+  if (!Number.isFinite(parsed)) {
+    throw new Error(`${name}: "${raw}" is not a real timestamp`);
+  }
+  // Normalize to millisecond precision: stamps are new Date().toISOString(),
+  // so identical formats make lexicographic order equal chronological order.
+  return new Date(parsed).toISOString();
+}
+
+export function parseRefreshArgs(args: string[]): CLIOptions {
+  const options: CLIOptions = {
+    dryRun: false,
+    refresh: false,
+    delayMs: REQUEST_DELAY_MS,
+  };
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+
+    switch (arg) {
+      case '--limit':
+        options.limit = intFlag('--limit', args, i++);
+        break;
+      case '--year-start':
+        options.yearStart = intFlag('--year-start', args, i++);
+        break;
+      case '--year-end':
+        options.yearEnd = intFlag('--year-end', args, i++);
+        break;
+      case '--max-pages':
+        options.maxPages = intFlag('--max-pages', args, i++);
+        break;
+      case '--delay-ms':
+        options.delayMs = intFlag('--delay-ms', args, i++);
+        break;
+      case '--dry-run':
+        options.dryRun = true;
+        break;
+      case '--refresh':
+        options.refresh = true;
+        break;
+      case '--skip-stamped-since':
+        options.skipStampedSince = isoUtcFlag('--skip-stamped-since', args, i++);
+        break;
+      case '--report':
+        options.reportPath = flagValue('--report', args, i++);
+        break;
+      case '--no-skip':
+        // Legacy alias: a full refetch regardless of stamps is --refresh
+        // without --skip-stamped-since.
+        options.refresh = true;
+        break;
+      default:
+        throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+
+  // The floor applies to --dry-run too: dry runs still fetch every live
+  // sitemap page from retsinformation.dk.
+  if (options.delayMs < REQUEST_DELAY_MS) {
+    throw new Error(
+      `--delay-ms ${options.delayMs} is below the ${REQUEST_DELAY_MS}ms politeness floor for retsinformation.dk`,
+    );
+  }
+
+  return options;
+}

--- a/scripts/lib/refresh-policy.ts
+++ b/scripts/lib/refresh-policy.ts
@@ -1,0 +1,97 @@
+/**
+ * Version-keyed refresh decisions for the Retsinformation corpus (issue #89,
+ * ported from Dutch-law-mcp#117/#119).
+ *
+ * Danish upstream reality, measured 2026-06-10:
+ *   - The sitemap lastmod does NOT track status/metadata changes: 2019/241
+ *     was historic-marked 2019-07-04 and EndDate-stamped during 2026, yet
+ *     its lastmod is still its publication date 2019-03-16. lastmod can
+ *     therefore never PROVE a seed current.
+ *   - The harvest API (api.retsinformation.dk/v1/Documents) serves only a
+ *     10-day window — useless for reconstructing changes since the
+ *     2026-02-15 sweep, fine for daily incremental harvest going forward.
+ *
+ * Consequence: there is no cheap per-document currency proof. The policy
+ * refetches whenever freshness is unproven (accuracy over cheapness). The
+ * only skips are exact:
+ *   - additive mode (refresh=false) keeps the historic skip-existing
+ *     behaviour;
+ *   - `skipStampedSince` skips seeds this very run already stamped — exact
+ *     resume after an interruption, not a freshness heuristic;
+ *   - unstamped seeds (the entire pre-fix corpus) self-heal unconditionally.
+ */
+
+import type { VersionIdentity, SeedStatus } from './version-identity.js';
+
+export interface SeedIngestMeta extends VersionIdentity {
+  /** ISO timestamp the seed content was fetched. */
+  retrieved_at: string;
+  /** Seed status derived from the identity at stamp time. */
+  seed_status: SeedStatus;
+}
+
+export type FetchDecision =
+  | 'fetch_new'
+  | 'refetch_changed'
+  | 'refetch_unknown'
+  | 'skip_current'
+  | 'skip_existing';
+
+export function decideFetch(opts: {
+  seedExists: boolean;
+  refresh: boolean;
+  existingMeta?: SeedIngestMeta | null;
+  /**
+   * Skip seeds stamped at/after this ISO timestamp (same-run resume cutoff:
+   * pass the start time of the interrupted run).
+   */
+  skipStampedSince?: string | null;
+  /** ISO 'YYYY-MM-DD'. */
+  today: string;
+}): FetchDecision {
+  if (!opts.seedExists) return 'fetch_new';
+  if (!opts.refresh) return 'skip_existing';
+
+  // A seed without a stamp predates version-identity acquisition and may
+  // carry a silently-defaulted status. No fallback may ever prove such a
+  // seed current — self-heal is unconditional.
+  const meta = opts.existingMeta;
+  if (!meta || !meta.retrieved_at) return 'refetch_unknown';
+
+  if (opts.skipStampedSince && meta.retrieved_at >= opts.skipStampedSince) {
+    return 'skip_current';
+  }
+
+  // The stamped amended-through window (<EndDate>) closed after the stamp
+  // was written: upstream has registered later amendments, so a newer
+  // consolidation may exist. Refetch and let the served <Status> decide —
+  // EndDate alone is never a status claim.
+  if (meta.seed_status === 'in_force' && meta.end_date && meta.end_date < opts.today) {
+    return 'refetch_changed';
+  }
+
+  return 'refetch_unknown';
+}
+
+/** Stamp one canonical `_ingest` shape onto a seed object. */
+export function stampIngestMeta<T extends object>(
+  seed: T,
+  identity: VersionIdentity,
+  seedStatus: SeedStatus,
+  now: string,
+): T & { _ingest: SeedIngestMeta } {
+  return {
+    ...seed,
+    _ingest: {
+      retrieved_at: now,
+      accession: identity.accession,
+      document_id: identity.document_id,
+      unique_document_id: identity.unique_document_id,
+      upstream_status: identity.upstream_status,
+      start_date: identity.start_date,
+      end_date: identity.end_date,
+      historic_marked: identity.historic_marked,
+      seed_status: seedStatus,
+    },
+  };
+}

--- a/scripts/lib/refresh-worklist.ts
+++ b/scripts/lib/refresh-worklist.ts
@@ -1,0 +1,101 @@
+/**
+ * Refresh worklist construction + fail-loud run summary (issue #89).
+ *
+ * The worklist is the UNION of today's sitemap documents and the seeds we
+ * already hold: 656 held seeds are absent from the 2026-06-10 sitemap and a
+ * sitemap-only iteration would silently never revisit them. Absence from the
+ * sitemap is NOT gone-evidence — only a 404/410 on the document URL is.
+ */
+
+export interface SitemapEntry {
+  /** Canonical 'YYYY_N' id. */
+  id: string;
+  /** Document page URL as listed in the sitemap. */
+  url: string;
+  lastmod: string | null;
+}
+
+export interface WorkItem {
+  id: string;
+  /** XML payload URL on the canonical https://www.retsinformation.dk host. */
+  xmlUrl: string;
+  lastmod: string | null;
+  seedExists: boolean;
+  inSitemap: boolean;
+}
+
+function xmlUrlForId(id: string): string {
+  const [year, number] = id.split('_');
+  return `https://www.retsinformation.dk/eli/lta/${year}/${Number(number)}/xml`;
+}
+
+export function buildWorklist(opts: {
+  sitemapEntries: SitemapEntry[];
+  existingSeedIds: Iterable<string>;
+}): WorkItem[] {
+  const seeds = new Set(opts.existingSeedIds);
+  const out = new Map<string, WorkItem>();
+
+  for (const entry of opts.sitemapEntries) {
+    out.set(entry.id, {
+      id: entry.id,
+      xmlUrl: xmlUrlForId(entry.id),
+      lastmod: entry.lastmod ?? null,
+      seedExists: seeds.has(entry.id),
+      inSitemap: true,
+    });
+  }
+
+  for (const id of seeds) {
+    if (out.has(id)) continue;
+    out.set(id, {
+      id,
+      xmlUrl: xmlUrlForId(id),
+      lastmod: null,
+      seedExists: true,
+      inSitemap: false,
+    });
+  }
+
+  return [...out.values()];
+}
+
+export interface RunStats {
+  total: number;
+  fetched: number;
+  skipped: number;
+  failed: Array<{ id: string; error: string }>;
+  goneUpstream: Array<{ id: string; httpStatus: number }>;
+}
+
+export interface RunSummary {
+  exitCode: 0 | 2;
+  lines: string[];
+}
+
+/**
+ * Fail-loud summary: any failure makes the run exit non-zero (2) so an
+ * unattended sweep can never look complete when it was not. Gone-upstream
+ * findings (positive 404/410 evidence) are enumerated but are not failures —
+ * the seed is kept and the operator decides.
+ */
+export function summarizeRun(stats: RunStats): RunSummary {
+  const lines: string[] = [];
+  lines.push(`total=${stats.total} fetched=${stats.fetched} skipped=${stats.skipped} failed=${stats.failed.length} gone_upstream=${stats.goneUpstream.length}`);
+
+  if (stats.goneUpstream.length > 0) {
+    lines.push(`GONE UPSTREAM (positive 404/410 evidence; seeds kept, review required):`);
+    for (const g of stats.goneUpstream) {
+      lines.push(`  gone ${g.id} (HTTP ${g.httpStatus})`);
+    }
+  }
+
+  if (stats.failed.length > 0) {
+    lines.push(`FAILED (transient or unmapped — NOT gone; rerun with --refresh --skip-stamped-since <run-start>):`);
+    for (const f of stats.failed) {
+      lines.push(`  failed ${f.id}: ${f.error}`);
+    }
+  }
+
+  return { exitCode: stats.failed.length > 0 ? 2 : 0, lines };
+}

--- a/scripts/lib/refresh-worklist.ts
+++ b/scripts/lib/refresh-worklist.ts
@@ -7,6 +7,9 @@
  * sitemap is NOT gone-evidence — only a 404/410 on the document URL is.
  */
 
+import * as fs from 'fs';
+import * as path from 'path';
+
 export interface SitemapEntry {
   /** Canonical 'YYYY_N' id. */
   id: string;
@@ -60,12 +63,71 @@ export function buildWorklist(opts: {
   return [...out.values()];
 }
 
+/**
+ * The identity we ALREADY SERVE under a seed path — the seed file's `id`.
+ * This is what the identity gate compares the served document against, never
+ * a re-derived format: pre-1901 statutes legitimately carry DocumentId
+ * fallback ids (AL000501, CM016392, ...) which are the prod-stable citation
+ * identity. Missing/torn/id-less seeds have no held identity (null): the
+ * refetched document's served id becomes the identity, which is exactly the
+ * documented self-heal path for unreadable seeds.
+ */
+export function readHeldSeedId(seedPath: string): string | null {
+  try {
+    const seed = JSON.parse(fs.readFileSync(seedPath, 'utf-8')) as { id?: unknown };
+    return typeof seed.id === 'string' && seed.id.trim().length > 0 ? seed.id : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Quarantine a gone-upstream seed (PR #90 round 2, Dutch-law-mcp 976c0ef):
+ * a gone document's seed must not keep flowing into builds as current law.
+ * Rename — never delete — so the operator can audit/restore and the corpus
+ * differ surfaces the removal at swap time. Returns the quarantine path, or
+ * null when there was no held seed.
+ */
+export function quarantineGoneSeed(seedPath: string, quarantineDir: string): string | null {
+  if (!fs.existsSync(seedPath)) return null;
+  fs.mkdirSync(quarantineDir, { recursive: true });
+  const destPath = path.join(quarantineDir, path.basename(seedPath));
+  fs.renameSync(seedPath, destPath);
+  return destPath;
+}
+
+/**
+ * Apply --limit so the budget counts only items that actually FETCH. Skip
+ * decisions pass through free: a fully-stamped prefix must not starve the
+ * budget, otherwise every chunked `--limit N` resume reprocesses the same
+ * already-done window, reports fetched=0, exits 0 and the sweep never
+ * advances.
+ */
+export function applyLimit<T extends { decision: string }>(decided: T[], limit?: number): T[] {
+  if (!limit || !Number.isFinite(limit) || limit <= 0) return decided;
+
+  const queue: T[] = [];
+  let budget = 0;
+
+  for (const item of decided) {
+    if (item.decision === 'skip_existing' || item.decision === 'skip_current') {
+      queue.push(item);
+      continue;
+    }
+    if (budget === limit) break;
+    queue.push(item);
+    budget += 1;
+  }
+
+  return queue;
+}
+
 export interface RunStats {
   total: number;
   fetched: number;
   skipped: number;
   failed: Array<{ id: string; error: string }>;
-  goneUpstream: Array<{ id: string; httpStatus: number }>;
+  goneUpstream: Array<{ id: string; httpStatus: number; quarantined: boolean }>;
 }
 
 export interface RunSummary {
@@ -84,9 +146,11 @@ export function summarizeRun(stats: RunStats): RunSummary {
   lines.push(`total=${stats.total} fetched=${stats.fetched} skipped=${stats.skipped} failed=${stats.failed.length} gone_upstream=${stats.goneUpstream.length}`);
 
   if (stats.goneUpstream.length > 0) {
-    lines.push(`GONE UPSTREAM (positive 404/410 evidence; seeds kept, review required):`);
+    lines.push(`GONE UPSTREAM (positive 404/410 evidence; held seeds quarantined to data/seed-gone/, review required):`);
     for (const g of stats.goneUpstream) {
-      lines.push(`  gone ${g.id} (HTTP ${g.httpStatus})`);
+      lines.push(
+        `  gone ${g.id} (HTTP ${g.httpStatus}) — ${g.quarantined ? 'seed quarantined to data/seed-gone/' : 'no held seed'}`,
+      );
     }
   }
 

--- a/scripts/lib/refresh-worklist.ts
+++ b/scripts/lib/refresh-worklist.ts
@@ -73,11 +73,22 @@ export function buildWorklist(opts: {
  * documented self-heal path for unreadable seeds.
  */
 export function readHeldSeedId(seedPath: string): string | null {
+  let raw: string;
   try {
-    const seed = JSON.parse(fs.readFileSync(seedPath, 'utf-8')) as { id?: unknown };
+    raw = fs.readFileSync(seedPath, 'utf-8');
+  } catch (error) {
+    // Self-heal (null) is reserved for the never-held case. Any other fs
+    // failure (EACCES, EIO, EMFILE, ...) is transient/environmental: it must
+    // fail the item loudly, NOT disable the identity gate and authorize
+    // overwriting the held good seed (PR #90 round 3).
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return null;
+    throw error;
+  }
+  try {
+    const seed = JSON.parse(raw) as { id?: unknown };
     return typeof seed.id === 'string' && seed.id.trim().length > 0 ? seed.id : null;
   } catch {
-    return null;
+    return null; // torn/invalid JSON: the documented self-heal class
   }
 }
 
@@ -91,7 +102,16 @@ export function readHeldSeedId(seedPath: string): string | null {
 export function quarantineGoneSeed(seedPath: string, quarantineDir: string): string | null {
   if (!fs.existsSync(seedPath)) return null;
   fs.mkdirSync(quarantineDir, { recursive: true });
-  const destPath = path.join(quarantineDir, path.basename(seedPath));
+  // Never overwrite earlier quarantine evidence: a second 404 for the same
+  // id (e.g. after an operator restore-by-copy) must not destroy the first
+  // quarantined copy (PR #90 round 3) — uniquify instead.
+  const base = path.basename(seedPath, '.json');
+  let destPath = path.join(quarantineDir, `${base}.json`);
+  let n = 1;
+  while (fs.existsSync(destPath)) {
+    destPath = path.join(quarantineDir, `${base}.gone-${n}.json`);
+    n += 1;
+  }
   fs.renameSync(seedPath, destPath);
   return destPath;
 }

--- a/scripts/lib/run-report.ts
+++ b/scripts/lib/run-report.ts
@@ -1,0 +1,88 @@
+/**
+ * Durable run records for the bulk refresh runner (PR #90 round 2).
+ *
+ * The killed 51h sweep left no machine-readable record of its start time —
+ * the exact --skip-stamped-since resume cutoff — because the report was
+ * written only at successful completion and its default path was keyed by
+ * date only (a same-day rerun overwrote it, destroying the only durable
+ * enumeration of failures). Now:
+ *
+ *   - a run-start MARKER file (run-stamped name) is written at startup;
+ *   - the report path is run-stamped, never date-only;
+ *   - SIGINT/SIGTERM write a partial report before exiting.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { writeFileAtomic } from './atomic-write.js';
+
+/** Filesystem-safe stamp preserving full timestamp precision. */
+export function runStamp(runStartedAt: string): string {
+  return runStartedAt.replace(/[:.]/g, '-');
+}
+
+export function buildReportPath(
+  reportDir: string,
+  runStartedAt: string,
+  overridePath?: string,
+): string {
+  return overridePath ?? path.join(reportDir, `ingest-refresh-${runStamp(runStartedAt)}.json`);
+}
+
+/**
+ * Write the run-start marker. Returns the marker path. The marker is the
+ * recovery record: if the run dies without a report, the cutoff for
+ * `--refresh --skip-stamped-since <run_started_at>` is read from here.
+ */
+export function writeRunMarker(
+  reportDir: string,
+  payload: { run_started_at: string; [key: string]: unknown },
+): string {
+  const markerPath = path.join(reportDir, `run-started-${runStamp(payload.run_started_at)}.json`);
+  fs.mkdirSync(reportDir, { recursive: true });
+  writeFileAtomic(markerPath, `${JSON.stringify(payload, null, 2)}\n`);
+  return markerPath;
+}
+
+export function writeReport(reportPath: string, payload: unknown): void {
+  fs.mkdirSync(path.dirname(reportPath), { recursive: true });
+  writeFileAtomic(reportPath, `${JSON.stringify(payload, null, 2)}\n`);
+}
+
+const SIGNAL_EXIT_CODES: Record<'SIGINT' | 'SIGTERM', number> = {
+  SIGINT: 130,
+  SIGTERM: 143,
+};
+
+/**
+ * Build a signal handler that writes a partial report (best effort — a
+ * broken disk must not hang shutdown) and exits with the conventional
+ * 128+signal code.
+ */
+export function makeInterruptHandler(ctx: {
+  reportPath: string;
+  payload: () => unknown;
+  exitFn?: (code: number) => void;
+  log?: (line: string) => void;
+}): (signal: 'SIGINT' | 'SIGTERM') => void {
+  const exitFn = ctx.exitFn ?? ((code: number): void => process.exit(code));
+  const log = ctx.log ?? ((line: string): void => console.error(line));
+
+  return (signal: 'SIGINT' | 'SIGTERM'): void => {
+    try {
+      const base = ctx.payload();
+      const payload =
+        typeof base === 'object' && base !== null
+          ? { ...(base as Record<string, unknown>), interrupted_by: signal, partial: true }
+          : { payload: base, interrupted_by: signal, partial: true };
+      writeReport(ctx.reportPath, payload);
+      log(`${signal}: partial report written: ${ctx.reportPath}`);
+    } catch (error) {
+      log(
+        `${signal}: failed to write partial report (${error instanceof Error ? error.message : String(error)}) — ` +
+          'the run-start marker still holds the resume cutoff',
+      );
+    }
+    exitFn(SIGNAL_EXIT_CODES[signal]);
+  };
+}

--- a/scripts/lib/sitemap.ts
+++ b/scripts/lib/sitemap.ts
@@ -1,0 +1,140 @@
+/**
+ * Retsinformation sitemap acquisition (PR #90 round 2).
+ *
+ * Parsing is tolerant: <url> children are matched order-independently and
+ * standard optional elements (<changefreq>, <priority>) are allowed — the
+ * old regex required the exact sequence loc[,lastmod] and any schema-valid
+ * upstream change yielded ZERO entries.
+ *
+ * Sanity floor: a sitemap that yields zero page URLs or zero document
+ * entries FAILS the run (SitemapSanityError). The worklist is a union with
+ * held seeds, so a silently-empty sitemap would otherwise degrade the sweep
+ * to a seeds-only run that exits 0 and never fetches new law.
+ */
+
+import type { SitemapEntry } from './refresh-worklist.js';
+
+export class SitemapSanityError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'SitemapSanityError';
+  }
+}
+
+export function extractSitemapLocs(xml: string): string[] {
+  const locs: string[] = [];
+  const pattern = /<loc>\s*([^<]+?)\s*<\/loc>/g;
+
+  for (const match of xml.matchAll(pattern)) {
+    const url = match[1]?.trim();
+    if (url) locs.push(url);
+  }
+
+  return locs;
+}
+
+export function extractUrlEntries(xml: string): Array<{ loc: string; lastmod?: string }> {
+  const entries: Array<{ loc: string; lastmod?: string }> = [];
+  const blockPattern = /<url\b[^>]*>([\s\S]*?)<\/url>/g;
+
+  for (const match of xml.matchAll(blockPattern)) {
+    const block = match[1];
+    const loc = block.match(/<loc>\s*([^<]+?)\s*<\/loc>/)?.[1]?.trim();
+    if (!loc) continue;
+
+    entries.push({
+      loc,
+      lastmod: block.match(/<lastmod>\s*([^<]+?)\s*<\/lastmod>/)?.[1]?.trim(),
+    });
+  }
+
+  return entries;
+}
+
+export function parseLawIdFromUrl(url: string): { year: number; number: number } | null {
+  const match = url.match(/\/eli\/lta\/(\d{4})\/(\d+)$/u);
+  if (!match) return null;
+
+  const year = Number.parseInt(match[1], 10);
+  const number = Number.parseInt(match[2], 10);
+
+  if (!Number.isFinite(year) || !Number.isFinite(number)) {
+    return null;
+  }
+
+  return { year, number };
+}
+
+async function defaultSleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export async function collectSitemapEntries(opts: {
+  indexUrl: string;
+  fetchText: (url: string) => Promise<string>;
+  /** Politeness pacing between page fetches (enforced by the CLI). */
+  delayMs: number;
+  maxPages?: number;
+  yearStart?: number;
+  yearEnd?: number;
+  sleepFn?: (ms: number) => Promise<void>;
+  log?: (line: string) => void;
+}): Promise<SitemapEntry[]> {
+  const sleepFn = opts.sleepFn ?? defaultSleep;
+  const log = opts.log ?? console.log;
+
+  log('Fetching sitemap index...');
+  const indexXml = await opts.fetchText(opts.indexUrl);
+  let sitemapPages = extractSitemapLocs(indexXml).filter((url) =>
+    /sitemap\.xml\?page=\d+$/u.test(url),
+  );
+
+  if (sitemapPages.length === 0) {
+    throw new SitemapSanityError(
+      `sitemap index ${opts.indexUrl} yielded ZERO page URLs — maintenance page, truncated body, ` +
+        'or upstream URL-shape change. Refusing to degrade to a seeds-only run.',
+    );
+  }
+
+  if (opts.maxPages && opts.maxPages > 0) {
+    sitemapPages = sitemapPages.slice(0, opts.maxPages);
+  }
+
+  log(`Sitemap pages to scan: ${sitemapPages.length}`);
+
+  const entries = new Map<string, SitemapEntry>();
+
+  for (let i = 0; i < sitemapPages.length; i++) {
+    const pageUrl = sitemapPages[i];
+    log(`  [${i + 1}/${sitemapPages.length}] ${pageUrl}`);
+
+    await sleepFn(opts.delayMs);
+    const pageXml = await opts.fetchText(pageUrl);
+
+    for (const entry of extractUrlEntries(pageXml)) {
+      const parsed = parseLawIdFromUrl(entry.loc);
+      if (!parsed) continue;
+
+      if (opts.yearStart && parsed.year < opts.yearStart) continue;
+      if (opts.yearEnd && parsed.year > opts.yearEnd) continue;
+
+      const id = `${parsed.year}_${parsed.number}`;
+      const existing = entries.get(id);
+      if (!existing || (entry.lastmod ?? '') > (existing.lastmod ?? '')) {
+        entries.set(id, { id, url: entry.loc, lastmod: entry.lastmod ?? null });
+      }
+    }
+  }
+
+  if (entries.size === 0) {
+    throw new SitemapSanityError(
+      `sitemap pages yielded ZERO /eli/lta document entries (scanned ${sitemapPages.length} pages) — ` +
+        'parse failure or upstream shape change. Refusing to degrade to a seeds-only run.' +
+        (opts.maxPages
+          ? ` NOTE: --max-pages ${opts.maxPages} truncated the scan; on this upstream page 1 is the site-nav page with no documents — try a deeper scan.`
+          : ''),
+    );
+  }
+
+  return [...entries.values()];
+}

--- a/scripts/lib/version-identity.ts
+++ b/scripts/lib/version-identity.ts
@@ -74,7 +74,8 @@ function textOf(node: unknown): string | null {
   return null;
 }
 
-function isoDateOf(node: unknown): string | null {
+/** Attribute-tolerant ISO date extraction (handles { '#text': ..., REFid } nodes). */
+export function isoDateOf(node: unknown): string | null {
   const text = textOf(node);
   if (!text) return null;
   const m = text.match(/\d{4}-\d{2}-\d{2}/);
@@ -94,7 +95,13 @@ export function extractVersionIdentity(meta: Record<string, unknown>): VersionId
   };
 }
 
-const IN_FORCE_STATUSES = new Set(['valid', 'gældende', 'gaeldende', 'gallende']);
+// Observed live (2026-06-10): 'Valid' and 'Historic'. The Danish-language
+// equivalents ('gældende', 'historisk') are kept as deliberate, real-word
+// mappings in case upstream localizes. NOTHING ELSE: pre-authorizing guessed
+// vocabulary ('gallende' — not a Danish word; 'gaeldende' — an ASCII fold
+// upstream has never served) is the same silent-default class issue #89
+// removed, moved into the accept-set. Unknown vocabulary THROWS below.
+const IN_FORCE_STATUSES = new Set(['valid', 'gældende']);
 const REPEALED_STATUSES = new Set(['historic', 'historisk']);
 
 /**

--- a/scripts/lib/version-identity.ts
+++ b/scripts/lib/version-identity.ts
@@ -1,0 +1,115 @@
+/**
+ * Version identity of a served Retsinformation document (issue #89).
+ *
+ * Every /eli/lta/{year}/{number}/xml payload identifies exactly which
+ * consolidation it is (AccessionNumber) and whether it is still current law
+ * (<Status> + validity window). The 2026-02-15 bulk sweep threw this
+ * information away and silently defaulted every unrecognized <Status> text
+ * (including "Historic") to in_force — 22,182 of 62,762 seeds carry a
+ * fetch-time historic doc-type marker yet claim to be current.
+ *
+ * Rules (verified against live upstream 2026-06-10):
+ *   - `<Status>` is the per-document currency signal: Valid = current law,
+ *     Historic = superseded. The website's own timeline API agrees
+ *     (isHistoric flag).
+ *   - `<EndDate>` is NOT supersession evidence — it is the date the
+ *     consolidation is amended/tracked through. Proven live: kursgevinstloven
+ *     LBK 2025/1176 serves Status=Valid with EndDate 2026-01-20 in the past
+ *     and its timeline says isHistoric=false (current). Mapping EndDate-past
+ *     to repealed would wrongly repeal current law. EndDate is stamped in
+ *     `_ingest` for refresh decisions only.
+ *   - Mapping is EXPLICIT. Unknown or missing status vocabulary THROWS
+ *     UnknownUpstreamStatusError; the caller records the document as failed.
+ *     Accuracy over availability — a wrong "in_force" is worse than a gap.
+ */
+
+export interface VersionIdentity {
+  /** AccessionNumber of the served consolidation, e.g. 'A20190024129'. */
+  accession: string | null;
+  /** Retsinformation DocumentId, e.g. 'CK002013'. */
+  document_id: string | null;
+  /** UniqueDocumentId, e.g. '207970'. */
+  unique_document_id: string | null;
+  /** Raw <Status> text exactly as served, e.g. 'Historic', 'Valid'. */
+  upstream_status: string | null;
+  /** <StartDate> (validity start), ISO 'YYYY-MM-DD'. */
+  start_date: string | null;
+  /** <EndDate> (validity end), ISO 'YYYY-MM-DD'. */
+  end_date: string | null;
+  /** <DateOfHistoricMark>, ISO 'YYYY-MM-DD'. */
+  historic_marked: string | null;
+}
+
+export type SeedStatus = 'in_force' | 'repealed' | 'not_yet_in_force';
+
+export class UnknownUpstreamStatusError extends Error {
+  constructor(statusText: string | null) {
+    super(
+      `unknown upstream status ${statusText === null ? '<missing>' : JSON.stringify(statusText)} — ` +
+        'refusing to guess (the 2026-02-15 sweep defaulted "Historic" to in_force). ' +
+        'Extend the explicit mapping in scripts/lib/version-identity.ts deliberately.',
+    );
+    this.name = 'UnknownUpstreamStatusError';
+  }
+}
+
+function textOf(node: unknown): string | null {
+  if (node == null) return null;
+  if (typeof node === 'string' || typeof node === 'number' || typeof node === 'boolean') {
+    const s = String(node).trim();
+    return s.length > 0 ? s : null;
+  }
+  if (Array.isArray(node)) {
+    for (const item of node) {
+      const t = textOf(item);
+      if (t) return t;
+    }
+    return null;
+  }
+  if (typeof node === 'object') {
+    const record = node as Record<string, unknown>;
+    // fast-xml-parser puts element text under '#text' when attributes exist.
+    if ('#text' in record) return textOf(record['#text']);
+  }
+  return null;
+}
+
+function isoDateOf(node: unknown): string | null {
+  const text = textOf(node);
+  if (!text) return null;
+  const m = text.match(/\d{4}-\d{2}-\d{2}/);
+  return m ? m[0] : null;
+}
+
+/** Extract the served consolidation identity from a parsed Dokument.Meta node. */
+export function extractVersionIdentity(meta: Record<string, unknown>): VersionIdentity {
+  return {
+    accession: textOf(meta.AccessionNumber),
+    document_id: textOf(meta.DocumentId),
+    unique_document_id: textOf(meta.UniqueDocumentId),
+    upstream_status: textOf(meta.Status),
+    start_date: isoDateOf(meta.StartDate),
+    end_date: isoDateOf(meta.EndDate),
+    historic_marked: isoDateOf(meta.DateOfHistoricMark),
+  };
+}
+
+const IN_FORCE_STATUSES = new Set(['valid', 'gældende', 'gaeldende', 'gallende']);
+const REPEALED_STATUSES = new Set(['historic', 'historisk']);
+
+/**
+ * Map a served version identity to the seed status: explicit status
+ * vocabulary first, then the in-force date window, then REFUSE.
+ */
+export function mapSeedStatus(identity: VersionIdentity, today: string): SeedStatus {
+  const raw = identity.upstream_status;
+  const normalized = (raw ?? '').trim().toLowerCase();
+
+  if (REPEALED_STATUSES.has(normalized)) return 'repealed';
+  if (IN_FORCE_STATUSES.has(normalized)) {
+    if (identity.start_date && identity.start_date > today) return 'not_yet_in_force';
+    return 'in_force';
+  }
+
+  throw new UnknownUpstreamStatusError(raw);
+}

--- a/sources.yml
+++ b/sources.yml
@@ -34,3 +34,22 @@ data_freshness:
   automated_checks: true
   check_frequency: 'daily'
   last_verified: '2026-02-15'
+
+# Fix-Sweep rebuild contract (chassis corpus freshness automation, 2026-06-10 survey).
+# Schema: Ansvar-Architecture-Documentation/infrastructure/policy/rebuild-contract.schema.json
+# Runbook: Ansvar-Architecture-Documentation/docs/runbooks/fix-sweep.md
+# ingest_cmd is the version-keyed refresh (issue #89): unstamped seeds
+# self-heal, statuses map explicitly from the served <Status>, partial runs
+# exit non-zero. NOT "npm run ingest:fetch" — that is a methodology-MCP
+# template artifact which exits 1 in this repo (no data/content directory).
+rebuild_contract:
+  schema_version: "1.0"
+  runnable: true
+  ingest_cmd: "npm run ingest:refresh"
+  build_cmd: "npm run build:db"
+  build_cwd: "."
+  premium_build_cmd: "npm run build:db:paid"
+  output_db: "data/database.db"
+  schema_kind: "statute"
+  drift_cmd: "npm run drift:detect"
+  golden_hashes: "fixtures/golden-hashes.json"

--- a/tests/ingest/atomic-write.test.ts
+++ b/tests/ingest/atomic-write.test.ts
@@ -1,0 +1,60 @@
+/**
+ * Atomic seed writes (PR #90 round 2). fs.writeFileSync over an existing seed
+ * opens with O_TRUNC: a kill/reboot mid-write destroys the previous good
+ * consolidation and leaves torn JSON that the GONE path and additive mode
+ * preserve forever. Writes must go to a sibling tmp file and rename over the
+ * destination — the destination is never opened for truncation.
+ */
+import { describe, it, expect } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { writeFileAtomic } from '../../scripts/lib/atomic-write.js';
+
+function tmpDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'dk-atomic-test-'));
+}
+
+const isRoot = typeof process.getuid === 'function' && process.getuid() === 0;
+
+describe('writeFileAtomic', () => {
+  it('writes the content and leaves no tmp sibling behind', () => {
+    const dir = tmpDir();
+    const file = path.join(dir, 'seed.json');
+    writeFileAtomic(file, '{"id":"2019:241"}\n');
+    expect(fs.readFileSync(file, 'utf-8')).toBe('{"id":"2019:241"}\n');
+    expect(fs.readdirSync(dir).filter((f) => f.includes('.tmp'))).toEqual([]);
+  });
+
+  it('replaces an existing file', () => {
+    const dir = tmpDir();
+    const file = path.join(dir, 'seed.json');
+    fs.writeFileSync(file, 'OLD', 'utf-8');
+    writeFileAtomic(file, 'NEW');
+    expect(fs.readFileSync(file, 'utf-8')).toBe('NEW');
+  });
+
+  it.skipIf(isRoot)(
+    'preserves the existing destination when the write fails — never truncate-then-write',
+    () => {
+      const dir = tmpDir();
+      const file = path.join(dir, 'seed.json');
+      fs.writeFileSync(file, '{"id":"1993:812","good":true}\n', 'utf-8');
+      // Read-only directory: creating the tmp sibling fails. The destination
+      // must be byte-identical afterwards — a plain writeFileSync would have
+      // truncated it before failing.
+      fs.chmodSync(dir, 0o555);
+      try {
+        expect(() => writeFileAtomic(file, '{"id":"WRONG"}')).toThrow();
+        expect(fs.readFileSync(file, 'utf-8')).toBe('{"id":"1993:812","good":true}\n');
+      } finally {
+        fs.chmodSync(dir, 0o755);
+      }
+    },
+  );
+
+  it('does not invent missing directories — a bad path fails loud', () => {
+    const dir = tmpDir();
+    expect(() => writeFileAtomic(path.join(dir, 'nope', 'seed.json'), 'x')).toThrow();
+  });
+});

--- a/tests/ingest/http-retry.test.ts
+++ b/tests/ingest/http-retry.test.ts
@@ -1,0 +1,61 @@
+/**
+ * Transient-vs-gone separation (issue #89, ported from Dutch-law-mcp#117).
+ *
+ * Transient failures (5xx, 429, network) retry with backoff and then THROW —
+ * they must never be soft-failed into "document gone". A 404 is returned to
+ * the caller: gone requires positive evidence and the caller decides.
+ */
+import { describe, it, expect } from 'vitest';
+import { fetchWithRetry } from '../../scripts/lib/http-retry.js';
+
+const FAST = { attempts: 3, backoffMs: [1, 1] };
+
+function fakeFetch(responses: Array<number | Error>): { impl: typeof fetch; calls: () => number } {
+  let i = 0;
+  const impl = (async () => {
+    const r = responses[Math.min(i, responses.length - 1)];
+    i += 1;
+    if (r instanceof Error) throw r;
+    return new Response('x', { status: r });
+  }) as unknown as typeof fetch;
+  return { impl, calls: () => i };
+}
+
+describe('fetchWithRetry', () => {
+  it('returns an ok response immediately', async () => {
+    const f = fakeFetch([200]);
+    const res = await fetchWithRetry('https://example.test/doc', { fetchImpl: f.impl, ...FAST });
+    expect(res.status).toBe(200);
+    expect(f.calls()).toBe(1);
+  });
+
+  it('retries 5xx then succeeds', async () => {
+    const f = fakeFetch([503, 200]);
+    const res = await fetchWithRetry('https://example.test/doc', { fetchImpl: f.impl, ...FAST });
+    expect(res.status).toBe(200);
+    expect(f.calls()).toBe(2);
+  });
+
+  it('retries network errors then THROWS after the attempt budget', async () => {
+    const f = fakeFetch([new Error('ECONNRESET')]);
+    await expect(
+      fetchWithRetry('https://example.test/doc', { fetchImpl: f.impl, ...FAST }),
+    ).rejects.toThrow(/failed after 3 attempts/);
+    expect(f.calls()).toBe(3);
+  });
+
+  it('retries 429 then THROWS — rate limiting is never "gone"', async () => {
+    const f = fakeFetch([429]);
+    await expect(
+      fetchWithRetry('https://example.test/doc', { fetchImpl: f.impl, ...FAST }),
+    ).rejects.toThrow(/HTTP 429/);
+    expect(f.calls()).toBe(3);
+  });
+
+  it('returns 404 to the caller without retrying — gone is a finding, not an error', async () => {
+    const f = fakeFetch([404]);
+    const res = await fetchWithRetry('https://example.test/doc', { fetchImpl: f.impl, ...FAST });
+    expect(res.status).toBe(404);
+    expect(f.calls()).toBe(1);
+  });
+});

--- a/tests/ingest/http-retry.test.ts
+++ b/tests/ingest/http-retry.test.ts
@@ -58,4 +58,28 @@ describe('fetchWithRetry', () => {
     expect(res.status).toBe(404);
     expect(f.calls()).toBe(1);
   });
+
+  it('retries respect a per-upstream pacing floor — backoff below the politeness floor is raised to it (PR #90 round 2)', async () => {
+    // The default backoff ladder starts at 1s; against retsinformation.dk the
+    // promised floor is 2s start-to-start INCLUDING retries. minDelayMs lifts
+    // every inter-attempt sleep to the floor.
+    const starts: number[] = [];
+    let i = 0;
+    const impl = (async () => {
+      starts.push(performance.now());
+      i += 1;
+      return new Response('x', { status: i < 3 ? 503 : 200 });
+    }) as unknown as typeof fetch;
+
+    const res = await fetchWithRetry('https://example.test/doc', {
+      fetchImpl: impl,
+      attempts: 3,
+      backoffMs: [1, 1],
+      minDelayMs: 200,
+    });
+    expect(res.status).toBe(200);
+    expect(starts).toHaveLength(3);
+    expect(starts[1] - starts[0]).toBeGreaterThanOrEqual(190);
+    expect(starts[2] - starts[1]).toBeGreaterThanOrEqual(190);
+  });
 });

--- a/tests/ingest/ingest-stamping.test.ts
+++ b/tests/ingest/ingest-stamping.test.ts
@@ -1,0 +1,149 @@
+/**
+ * ingest() must stamp the served consolidation identity and map status
+ * explicitly (issue #89). Proven live before the fix: seed 2019_241 held
+ * status in_force while its URL served <Status>Historic</Status> with
+ * <EndDate>2025-12-23</EndDate>.
+ */
+import { describe, it, expect } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { ingest, GoneUpstreamError } from '../../scripts/ingest-retsinformation.js';
+
+const TODAY = '2026-06-10';
+const NOW = '2026-06-10T22:00:00Z';
+
+function docXml(opts: { status?: string; endDate?: string; startDate?: string }): string {
+  return `<?xml version="1.0" encoding="utf-8"?>
+<Dokument id="d1">
+  <Meta id="m1">
+    <DocumentType>LBK H#LOKDOK03</DocumentType>
+    <AccessionNumber>A20190024129</AccessionNumber>
+    <DocumentId>CK002013</DocumentId>
+    <UniqueDocumentId>207970</UniqueDocumentId>
+    <DocumentTitle>Bekendtgørelse af lov om miljøbeskyttelse</DocumentTitle>
+    <Year>2019</Year>
+    <Number>241</Number>
+    <DiesSigni>2019-03-13</DiesSigni>
+    ${opts.startDate ? `<StartDate>${opts.startDate}</StartDate>` : ''}
+    ${opts.endDate ? `<EndDate>${opts.endDate}</EndDate>` : ''}
+    ${opts.status ? `<Status>${opts.status}</Status>` : ''}
+    <DateOfHistoricMark>2019-07-04</DateOfHistoricMark>
+  </Meta>
+  <Kapitel localId="1">
+    <Explicatus>Kapitel 1</Explicatus>
+    <Paragraf localId="1">
+      <Explicatus>§ 1</Explicatus>
+      <Char>Loven skal medvirke til at værne natur og miljø.</Char>
+    </Paragraf>
+  </Kapitel>
+</Dokument>`;
+}
+
+function fetchServing(body: string, status = 200): typeof fetch {
+  return (async () =>
+    new Response(body, { status, headers: { 'content-type': 'application/xml' } })) as unknown as typeof fetch;
+}
+
+function tmpOut(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'dk-ingest-test-'));
+  return path.join(dir, 'out.json');
+}
+
+describe('ingest version stamping', () => {
+  it('stamps _ingest with the served consolidation identity', async () => {
+    const out = tmpOut();
+    await ingest('https://www.retsinformation.dk/eli/lta/2019/241/xml', out, {
+      fetchImpl: fetchServing(docXml({ status: 'Historic', startDate: '2019-03-16', endDate: '2025-12-23' })),
+      now: NOW,
+      today: TODAY,
+    });
+    const seed = JSON.parse(fs.readFileSync(out, 'utf-8'));
+    expect(seed._ingest).toMatchObject({
+      retrieved_at: NOW,
+      accession: 'A20190024129',
+      document_id: 'CK002013',
+      unique_document_id: '207970',
+      upstream_status: 'Historic',
+      start_date: '2019-03-16',
+      end_date: '2025-12-23',
+      historic_marked: '2019-07-04',
+      seed_status: 'repealed',
+    });
+  });
+
+  it('maps Historic to repealed and records the historic-mark date as the validity end', async () => {
+    const out = tmpOut();
+    await ingest('https://www.retsinformation.dk/eli/lta/2019/241/xml', out, {
+      fetchImpl: fetchServing(docXml({ status: 'Historic', endDate: '2025-12-23' })),
+      now: NOW,
+      today: TODAY,
+    });
+    const seed = JSON.parse(fs.readFileSync(out, 'utf-8'));
+    expect(seed.status).toBe('repealed');
+    // DateOfHistoricMark (when the successor arrived) beats EndDate (the
+    // amended-through marker) as the validity end.
+    expect(seed.description).toContain('Ophævet 2019-07-04');
+    expect(seed.provision_versions[0].valid_to).toBe('2019-07-04');
+  });
+
+  it('does not set a validity end on Valid documents even when EndDate passed', async () => {
+    const out = tmpOut();
+    await ingest('https://www.retsinformation.dk/eli/lta/2025/1176/xml', out, {
+      fetchImpl: fetchServing(docXml({ status: 'Valid', startDate: '2025-10-03', endDate: '2026-01-20' })),
+      now: NOW,
+      today: TODAY,
+    });
+    const seed = JSON.parse(fs.readFileSync(out, 'utf-8'));
+    expect(seed.status).toBe('in_force');
+    expect(seed.description).not.toContain('Ophævet');
+    expect(seed.provision_versions[0].valid_to).toBeNull();
+  });
+
+  it('keeps Valid documents in_force', async () => {
+    const out = tmpOut();
+    await ingest('https://www.retsinformation.dk/eli/lta/2019/241/xml', out, {
+      fetchImpl: fetchServing(docXml({ status: 'Valid', startDate: '2019-03-16' })),
+      now: NOW,
+      today: TODAY,
+    });
+    const seed = JSON.parse(fs.readFileSync(out, 'utf-8'));
+    expect(seed.status).toBe('in_force');
+    expect(seed.provisions.length).toBeGreaterThan(0);
+  });
+
+  it('THROWS on unknown upstream status instead of defaulting to in_force', async () => {
+    const out = tmpOut();
+    await expect(
+      ingest('https://www.retsinformation.dk/eli/lta/2019/241/xml', out, {
+        fetchImpl: fetchServing(docXml({ status: 'Bortfaldet' })),
+        now: NOW,
+        today: TODAY,
+      }),
+    ).rejects.toThrow(/unknown upstream status/i);
+    expect(fs.existsSync(out)).toBe(false); // no seed written on refusal
+  });
+
+  it('raises GoneUpstreamError on 404 — positive evidence, distinguishable from transients', async () => {
+    const out = tmpOut();
+    await expect(
+      ingest('https://www.retsinformation.dk/eli/lta/1993/812/xml', out, {
+        fetchImpl: fetchServing('not found', 404),
+        now: NOW,
+        today: TODAY,
+      }),
+    ).rejects.toThrow(GoneUpstreamError);
+  });
+
+  it('returns the ingested identity so bulk callers can verify id expectations', async () => {
+    const out = tmpOut();
+    const result = await ingest('https://www.retsinformation.dk/eli/lta/2019/241/xml', out, {
+      fetchImpl: fetchServing(docXml({ status: 'Valid' })),
+      now: NOW,
+      today: TODAY,
+    });
+    expect(result.seedId).toBe('2019:241');
+    expect(result.status).toBe('in_force');
+    expect(result.identity.accession).toBe('A20190024129');
+  });
+});

--- a/tests/ingest/ingest-stamping.test.ts
+++ b/tests/ingest/ingest-stamping.test.ts
@@ -8,23 +8,31 @@ import { describe, it, expect } from 'vitest';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
-import { ingest, GoneUpstreamError } from '../../scripts/ingest-retsinformation.js';
+import { ingest, GoneUpstreamError, IdentityMismatchError } from '../../scripts/ingest-retsinformation.js';
 
 const TODAY = '2026-06-10';
 const NOW = '2026-06-10T22:00:00Z';
 
-function docXml(opts: { status?: string; endDate?: string; startDate?: string }): string {
+function docXml(opts: {
+  status?: string;
+  endDate?: string;
+  startDate?: string;
+  year?: string;
+  number?: string;
+  documentId?: string;
+  diesSigniAttr?: boolean;
+}): string {
   return `<?xml version="1.0" encoding="utf-8"?>
 <Dokument id="d1">
   <Meta id="m1">
     <DocumentType>LBK H#LOKDOK03</DocumentType>
     <AccessionNumber>A20190024129</AccessionNumber>
-    <DocumentId>CK002013</DocumentId>
+    <DocumentId>${opts.documentId ?? 'CK002013'}</DocumentId>
     <UniqueDocumentId>207970</UniqueDocumentId>
     <DocumentTitle>Bekendtgørelse af lov om miljøbeskyttelse</DocumentTitle>
-    <Year>2019</Year>
-    <Number>241</Number>
-    <DiesSigni>2019-03-13</DiesSigni>
+    <Year>${opts.year ?? '2019'}</Year>
+    <Number>${opts.number ?? '241'}</Number>
+    ${opts.diesSigniAttr ? '<DiesSigni REFid="submit_1">2019-03-13</DiesSigni>' : '<DiesSigni>2019-03-13</DiesSigni>'}
     ${opts.startDate ? `<StartDate>${opts.startDate}</StartDate>` : ''}
     ${opts.endDate ? `<EndDate>${opts.endDate}</EndDate>` : ''}
     ${opts.status ? `<Status>${opts.status}</Status>` : ''}
@@ -145,5 +153,93 @@ describe('ingest version stamping', () => {
     expect(result.seedId).toBe('2019:241');
     expect(result.status).toBe('in_force');
     expect(result.identity.accession).toBe('A20190024129');
+  });
+
+  it('parses issued_date from an attribute-carrying DiesSigni node, like every other date field', async () => {
+    const out = tmpOut();
+    await ingest('https://www.retsinformation.dk/eli/lta/2019/241/xml', out, {
+      fetchImpl: fetchServing(docXml({ status: 'Valid', diesSigniAttr: true })),
+      now: NOW,
+      today: TODAY,
+    });
+    const seed = JSON.parse(fs.readFileSync(out, 'utf-8'));
+    expect(seed.issued_date).toBe('2019-03-13');
+  });
+
+  it('writes the seed atomically — no tmp sibling survives a successful write', async () => {
+    const out = tmpOut();
+    await ingest('https://www.retsinformation.dk/eli/lta/2019/241/xml', out, {
+      fetchImpl: fetchServing(docXml({ status: 'Valid' })),
+      now: NOW,
+      today: TODAY,
+    });
+    expect(fs.existsSync(out)).toBe(true);
+    expect(fs.readdirSync(path.dirname(out)).filter((f) => f.includes('.tmp'))).toEqual([]);
+  });
+});
+
+describe('ingest identity gate (write-before-check inversion, PR #90 round 2)', () => {
+  it('REFUSES before any write when the served document is not the expected identity', async () => {
+    const out = tmpOut();
+    // The held seed: the identity we already serve under this path.
+    fs.writeFileSync(out, '{"id":"1993:812","sentinel":"held-good-consolidation"}\n', 'utf-8');
+
+    await expect(
+      ingest('https://www.retsinformation.dk/eli/lta/1993/812/xml', out, {
+        fetchImpl: fetchServing(docXml({ status: 'Valid' })), // serves 2019:241
+        now: NOW,
+        today: TODAY,
+        expectedId: '1993:812',
+      }),
+    ).rejects.toThrow(IdentityMismatchError);
+
+    // A body for a different document must never be written under this
+    // statute's identity (Dutch-law-mcp ingest-bwb.ts ordering).
+    expect(fs.readFileSync(out, 'utf-8')).toBe(
+      '{"id":"1993:812","sentinel":"held-good-consolidation"}\n',
+    );
+  });
+
+  it('mismatch refusal fires even when the served status vocabulary is unknown — identity first', async () => {
+    const out = tmpOut();
+    await expect(
+      ingest('https://www.retsinformation.dk/eli/lta/1993/812/xml', out, {
+        fetchImpl: fetchServing(docXml({ status: 'Bortfaldet' })),
+        now: NOW,
+        today: TODAY,
+        expectedId: '1993:812',
+      }),
+    ).rejects.toThrow(IdentityMismatchError);
+    expect(fs.existsSync(out)).toBe(false);
+  });
+
+  it('writes when the served identity matches expectedId', async () => {
+    const out = tmpOut();
+    const result = await ingest('https://www.retsinformation.dk/eli/lta/2019/241/xml', out, {
+      fetchImpl: fetchServing(docXml({ status: 'Valid' })),
+      now: NOW,
+      today: TODAY,
+      expectedId: '2019:241',
+    });
+    expect(result.seedId).toBe('2019:241');
+    expect(fs.existsSync(out)).toBe(true);
+  });
+
+  it('pre-1901 statutes keep their prod-stable DocumentId fallback id — issued citations must not break', async () => {
+    const out = tmpOut();
+    // CITATION-IDENTITY CONSTRAINT: the pre-fix corpus already serves these
+    // documents under DocumentId-fallback ids (AL000501 etc.). The id must
+    // stay the fallback, and a held-id expectation of that fallback passes.
+    const result = await ingest('https://www.retsinformation.dk/eli/lta/1852/11000/xml', out, {
+      fetchImpl: fetchServing(
+        docXml({ status: 'Valid', year: '1852', number: '11000', documentId: 'AL000501' }),
+      ),
+      now: NOW,
+      today: TODAY,
+      expectedId: 'AL000501',
+    });
+    expect(result.seedId).toBe('AL000501');
+    const seed = JSON.parse(fs.readFileSync(out, 'utf-8'));
+    expect(seed.id).toBe('AL000501');
   });
 });

--- a/tests/ingest/legacy-ingest-guard.test.ts
+++ b/tests/ingest/legacy-ingest-guard.test.ts
@@ -1,0 +1,37 @@
+/**
+ * Legacy Swedish-template seed writer must be unreachable (PR #90 round 2).
+ *
+ * scripts/ingest-relevant-laws.ts imports ingest() from ingest-riksdagen.js —
+ * Swedish Riksdagen API code with its own silent in_force defaulting and no
+ * _ingest stamping — and writes slug-named seeds that the refresh worklist's
+ * ^(\d{4})_(\d+)\.json$ regex can never see: poisoned seeds that can never
+ * self-heal. Ported guard: Dutch-law-mcp FORCE_LEGACY_INGEST (exit 2 +
+ * pointer).
+ */
+import { describe, it, expect } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+
+describe('ingest-relevant-laws legacy guard', () => {
+  it('exits 2 with a pointer unless FORCE_LEGACY_INGEST=1', { timeout: 30_000 }, () => {
+    const env = { ...process.env };
+    delete env.FORCE_LEGACY_INGEST;
+    const res = spawnSync(
+      process.execPath,
+      ['--import', 'tsx', 'scripts/ingest-relevant-laws.ts'],
+      { cwd: ROOT, env, encoding: 'utf-8', timeout: 25_000 },
+    );
+    expect(res.status).toBe(2);
+    expect(res.stderr).toMatch(/FORCE_LEGACY_INGEST/);
+    expect(res.stderr).toMatch(/ingest:auto-all|auto-ingest-all-statutes/);
+  });
+
+  it('is no longer shipped as an npm script', () => {
+    const pkg = JSON.parse(fs.readFileSync(path.join(ROOT, 'package.json'), 'utf-8'));
+    expect(pkg.scripts['ingest:relevant']).toBeUndefined();
+  });
+});

--- a/tests/ingest/process-worklist.test.ts
+++ b/tests/ingest/process-worklist.test.ts
@@ -157,12 +157,19 @@ describe('processWorklist gone-upstream quarantine', () => {
     const seedPath = writeSeed(seedDir, '1993_1054', { id: '1993:1054', status: 'in_force' });
     const stats = newStats();
 
-    await processWorklist([item('1993_1054', 'refetch_unknown', true)], OPTS, stats, {
-      ingestFn: goneIngest,
-      seedDir,
-      quarantineDir,
-      sleepFn: noSleep,
-    });
+    // Round 3: quarantine demands removal-grade evidence — sitemap-absent
+    // AND a second confirming 404 (the goneIngest fake 404s consistently).
+    await processWorklist(
+      [{ ...item('1993_1054', 'refetch_unknown', true), inSitemap: false }],
+      OPTS,
+      stats,
+      {
+        ingestFn: goneIngest,
+        seedDir,
+        quarantineDir,
+        sleepFn: noSleep,
+      },
+    );
 
     expect(fs.existsSync(seedPath)).toBe(false); // no longer served
     const quarantined = path.join(quarantineDir, '1993_1054.json');
@@ -176,12 +183,17 @@ describe('processWorklist gone-upstream quarantine', () => {
     const { seedDir, quarantineDir } = tmpDirs();
     const stats = newStats();
 
-    await processWorklist([item('2026_999', 'fetch_new', false)], OPTS, stats, {
-      ingestFn: goneIngest,
-      seedDir,
-      quarantineDir,
-      sleepFn: noSleep,
-    });
+    await processWorklist(
+      [{ ...item('2026_999', 'fetch_new', false), inSitemap: false }],
+      OPTS,
+      stats,
+      {
+        ingestFn: goneIngest,
+        seedDir,
+        quarantineDir,
+        sleepFn: noSleep,
+      },
+    );
 
     expect(stats.goneUpstream).toEqual([{ id: '2026_999', httpStatus: 404, quarantined: false }]);
   });
@@ -203,5 +215,77 @@ describe('processWorklist skips', () => {
     expect(writes).toEqual([]);
     expect(stats.skipped).toBe(2);
     expect(stats.total).toBe(2);
+  });
+});
+
+describe('gone-evidence strengthening (PR #90 round 3)', () => {
+  // Round 2 escalated the gone consequence to corpus removal (quarantine)
+  // on a SINGLE unretried 404. Removal-grade evidence now requires: the
+  // sitemap must NOT list the document, and a second probe must confirm.
+  it('treats 404 on a sitemap-listed document as a FAILURE, never gone', async () => {
+    const { seedDir, quarantineDir } = tmpDirs();
+    const seedPath = writeSeed(seedDir, '1993_812', { id: '1993:812' });
+    const stats = newStats();
+    const it812 = { ...item('1993_812', 'refetch_unknown', true), inSitemap: true };
+    const ingestFn = async (): Promise<IngestResult> => {
+      throw new GoneUpstreamError('url', 404);
+    };
+    await processWorklist([it812], OPTS, stats, { seedDir, quarantineDir, ingestFn, sleepFn: noSleep });
+    expect(stats.goneUpstream).toHaveLength(0);
+    expect(stats.failed).toHaveLength(1);
+    expect(stats.failed[0].error).toMatch(/sitemap/i);
+    expect(fs.existsSync(seedPath)).toBe(true); // seed untouched
+  });
+
+  it('re-probes a sitemap-absent 404 once and quarantines only on a second 404', async () => {
+    const { seedDir, quarantineDir } = tmpDirs();
+    writeSeed(seedDir, '1993_813', { id: '1993:813' });
+    const stats = newStats();
+    const it813 = { ...item('1993_813', 'refetch_unknown', true), inSitemap: false };
+    let calls = 0;
+    const ingestFn = async (): Promise<IngestResult> => {
+      calls += 1;
+      throw new GoneUpstreamError('url', 404);
+    };
+    await processWorklist([it813], OPTS, stats, { seedDir, quarantineDir, ingestFn, sleepFn: noSleep });
+    expect(calls).toBe(2); // confirming probe happened
+    expect(stats.goneUpstream).toHaveLength(1);
+    expect(stats.failed).toHaveLength(0);
+  });
+
+  it('a transient 404 that succeeds on the confirming probe is fetched, not gone', async () => {
+    const { seedDir, quarantineDir } = tmpDirs();
+    writeSeed(seedDir, '1993_814', { id: '1993:814' });
+    const stats = newStats();
+    const it814 = { ...item('1993_814', 'refetch_unknown', true), inSitemap: false };
+    let calls = 0;
+    const ingestFn = async (): Promise<IngestResult> => {
+      calls += 1;
+      if (calls === 1) throw new GoneUpstreamError('url', 404);
+      return { seedId: '1993:814', status: 'in_force' } as IngestResult;
+    };
+    await processWorklist([it814], OPTS, stats, { seedDir, quarantineDir, ingestFn, sleepFn: noSleep });
+    expect(stats.fetched).toBe(1);
+    expect(stats.goneUpstream).toHaveLength(0);
+  });
+});
+
+describe('identity-gate coverage for unheld identities (PR #90 round 3)', () => {
+  // fetch_new items and unreadable-held seeds had NO identity verification:
+  // a redirect to a different document's XML wrote the wrong body under the
+  // item's filename. The URL-derived id is now passed as a shape-conditional
+  // expectation: enforced when the served id is year:number-shaped.
+  it('passes the URL-derived id when no held identity exists', async () => {
+    const { seedDir, quarantineDir } = tmpDirs();
+    const stats = newStats();
+    const itNew = { ...item('2026_100', 'fetch_new', false), inSitemap: true };
+    let seen: IngestOptions | undefined;
+    const ingestFn = async (_u: string, _o: string, opts: IngestOptions): Promise<IngestResult> => {
+      seen = opts;
+      return { seedId: '2026:100', status: 'in_force' } as IngestResult;
+    };
+    await processWorklist([itNew], OPTS, stats, { seedDir, quarantineDir, ingestFn, sleepFn: noSleep });
+    expect(seen?.urlDerivedId).toBe('2026:100');
+    expect(seen?.expectedId).toBeUndefined();
   });
 });

--- a/tests/ingest/process-worklist.test.ts
+++ b/tests/ingest/process-worklist.test.ts
@@ -1,0 +1,207 @@
+/**
+ * Bulk-runner orchestration (PR #90 round 2).
+ *
+ * Three review findings live at this seam:
+ *  1. Identity gate ordering: the expectation passed to ingest() must be the
+ *     HELD seed's id (the identity we already serve), never a re-derived
+ *     year:number format — 77 pre-1901 statutes legitimately serve
+ *     DocumentId-fallback ids (CM016392, AL000501, ...) that are the
+ *     prod-stable citation identity.
+ *  2. Gone upstream (404/410) quarantines the held seed to data/seed-gone/
+ *     (rename, never delete, never keep serving) — a pre-fix unstamped seed
+ *     that 404s can never self-heal any other way.
+ *  3. Identity mismatches are recorded as failures WITHOUT touching the held
+ *     seed (refusal happens inside ingest(), before any write).
+ */
+import { describe, it, expect } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { processWorklist, type DecidedItem } from '../../scripts/auto-ingest-all-statutes.js';
+import {
+  GoneUpstreamError,
+  IdentityMismatchError,
+  type IngestOptions,
+  type IngestResult,
+} from '../../scripts/ingest-retsinformation.js';
+import type { RunStats } from '../../scripts/lib/refresh-worklist.js';
+
+function tmpDirs(): { seedDir: string; quarantineDir: string } {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'dk-worklist-test-'));
+  return { seedDir: path.join(root, 'seed'), quarantineDir: path.join(root, 'seed-gone') };
+}
+
+function newStats(): RunStats {
+  return { total: 0, fetched: 0, skipped: 0, failed: [], goneUpstream: [] };
+}
+
+function item(id: string, decision: DecidedItem['decision'], seedExists: boolean): DecidedItem {
+  const [year, number] = id.split('_');
+  return {
+    id,
+    xmlUrl: `https://www.retsinformation.dk/eli/lta/${year}/${Number(number)}/xml`,
+    lastmod: null,
+    seedExists,
+    inSitemap: true,
+    decision,
+  };
+}
+
+function writeSeed(seedDir: string, id: string, body: object): string {
+  fs.mkdirSync(seedDir, { recursive: true });
+  const p = path.join(seedDir, `${id}.json`);
+  fs.writeFileSync(p, `${JSON.stringify(body, null, 2)}\n`, 'utf-8');
+  return p;
+}
+
+const OPTS = { dryRun: false, delayMs: 0 };
+const noSleep = async (): Promise<void> => {};
+
+/** Fake ingest that mimics the real expectedId refusal contract. */
+function fakeIngest(servedId: string, writes: Array<{ outputPath?: string; opts?: IngestOptions }>) {
+  return async (
+    _identifier: string,
+    outputPath?: string,
+    opts: IngestOptions = {},
+  ): Promise<IngestResult> => {
+    if (opts.expectedId !== undefined && servedId !== opts.expectedId) {
+      throw new IdentityMismatchError('https://x/xml', servedId, opts.expectedId);
+    }
+    writes.push({ outputPath, opts });
+    if (outputPath) {
+      fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+      fs.writeFileSync(outputPath, JSON.stringify({ id: servedId }), 'utf-8');
+    }
+    return {
+      seedId: servedId,
+      outputPath: outputPath ?? '',
+      status: 'in_force',
+      identity: {
+        accession: null,
+        document_id: null,
+        unique_document_id: null,
+        upstream_status: 'Valid',
+        start_date: null,
+        end_date: null,
+        historic_marked: null,
+      },
+    };
+  };
+}
+
+describe('processWorklist identity gate', () => {
+  it('passes the HELD seed id as expectedId — pre-1901 fallback ids are the prod-stable identity', async () => {
+    const { seedDir, quarantineDir } = tmpDirs();
+    writeSeed(seedDir, '1852_11000', { id: 'AL000501', status: 'in_force' });
+    const writes: Array<{ outputPath?: string; opts?: IngestOptions }> = [];
+    const stats = newStats();
+
+    await processWorklist([item('1852_11000', 'refetch_unknown', true)], OPTS, stats, {
+      ingestFn: fakeIngest('AL000501', writes),
+      seedDir,
+      quarantineDir,
+      sleepFn: noSleep,
+    });
+
+    // The old gate re-derived '1852:11000' and recorded a FALSE mismatch on
+    // every full sweep. The held id must be the expectation instead.
+    expect(writes).toHaveLength(1);
+    expect(writes[0].opts?.expectedId).toBe('AL000501');
+    expect(stats.failed).toEqual([]);
+    expect(stats.fetched).toBe(1);
+  });
+
+  it('records a true mismatch as failed and leaves the held seed untouched', async () => {
+    const { seedDir, quarantineDir } = tmpDirs();
+    const seedPath = writeSeed(seedDir, '1993_812', { id: '1993:812', good: true });
+    const before = fs.readFileSync(seedPath, 'utf-8');
+    const stats = newStats();
+
+    await processWorklist([item('1993_812', 'refetch_unknown', true)], OPTS, stats, {
+      ingestFn: fakeIngest('2007:1016', []),
+      seedDir,
+      quarantineDir,
+      sleepFn: noSleep,
+    });
+
+    expect(stats.failed).toHaveLength(1);
+    expect(stats.failed[0].id).toBe('1993_812');
+    expect(stats.failed[0].error).toMatch(/identity mismatch/i);
+    expect(fs.readFileSync(seedPath, 'utf-8')).toBe(before);
+  });
+
+  it('fetch_new has no held identity: the served id IS the identity, no gate fires', async () => {
+    const { seedDir, quarantineDir } = tmpDirs();
+    const writes: Array<{ outputPath?: string; opts?: IngestOptions }> = [];
+    const stats = newStats();
+
+    await processWorklist([item('2026_510', 'fetch_new', false)], OPTS, stats, {
+      ingestFn: fakeIngest('2026:510', writes),
+      seedDir,
+      quarantineDir,
+      sleepFn: noSleep,
+    });
+
+    expect(writes[0].opts?.expectedId).toBeUndefined();
+    expect(stats.fetched).toBe(1);
+  });
+});
+
+describe('processWorklist gone-upstream quarantine', () => {
+  const goneIngest = async (): Promise<IngestResult> => {
+    throw new GoneUpstreamError('https://x/xml', 404);
+  };
+
+  it('quarantines the held seed to the quarantine dir — rename, not delete, never keep serving', async () => {
+    const { seedDir, quarantineDir } = tmpDirs();
+    const seedPath = writeSeed(seedDir, '1993_1054', { id: '1993:1054', status: 'in_force' });
+    const stats = newStats();
+
+    await processWorklist([item('1993_1054', 'refetch_unknown', true)], OPTS, stats, {
+      ingestFn: goneIngest,
+      seedDir,
+      quarantineDir,
+      sleepFn: noSleep,
+    });
+
+    expect(fs.existsSync(seedPath)).toBe(false); // no longer served
+    const quarantined = path.join(quarantineDir, '1993_1054.json');
+    expect(fs.existsSync(quarantined)).toBe(true); // preserved, not deleted
+    expect(JSON.parse(fs.readFileSync(quarantined, 'utf-8')).id).toBe('1993:1054');
+    expect(stats.goneUpstream).toEqual([{ id: '1993_1054', httpStatus: 404, quarantined: true }]);
+    expect(stats.failed).toEqual([]); // gone is a finding, not a failure
+  });
+
+  it('gone on a never-held document quarantines nothing but is still enumerated', async () => {
+    const { seedDir, quarantineDir } = tmpDirs();
+    const stats = newStats();
+
+    await processWorklist([item('2026_999', 'fetch_new', false)], OPTS, stats, {
+      ingestFn: goneIngest,
+      seedDir,
+      quarantineDir,
+      sleepFn: noSleep,
+    });
+
+    expect(stats.goneUpstream).toEqual([{ id: '2026_999', httpStatus: 404, quarantined: false }]);
+  });
+});
+
+describe('processWorklist skips', () => {
+  it('does not invoke ingest for skip decisions', async () => {
+    const { seedDir, quarantineDir } = tmpDirs();
+    const writes: Array<{ outputPath?: string; opts?: IngestOptions }> = [];
+    const stats = newStats();
+
+    await processWorklist(
+      [item('2019_241', 'skip_current', true), item('2007_1016', 'skip_existing', true)],
+      OPTS,
+      stats,
+      { ingestFn: fakeIngest('x', writes), seedDir, quarantineDir, sleepFn: noSleep },
+    );
+
+    expect(writes).toEqual([]);
+    expect(stats.skipped).toBe(2);
+    expect(stats.total).toBe(2);
+  });
+});

--- a/tests/ingest/refresh-cli.test.ts
+++ b/tests/ingest/refresh-cli.test.ts
@@ -1,0 +1,94 @@
+/**
+ * CLI argument validation for the bulk refresh runner (PR #90 round 2).
+ *
+ * Number.parseInt('abc') is NaN and `NaN < 2000` is false, so a typo'd
+ * --delay-ms silently disabled the politeness floor and the 63k-item sweep
+ * would hammer retsinformation.dk back-to-back. Every numeric flag must be
+ * Number.isFinite-validated; --skip-stamped-since (the resume lever that
+ * decides what gets SKIPPED) must be full ISO-8601 UTC or fail loud.
+ */
+import { describe, it, expect } from 'vitest';
+import { parseRefreshArgs, REQUEST_DELAY_MS } from '../../scripts/lib/refresh-cli.js';
+
+describe('parseRefreshArgs — numeric flags', () => {
+  it('defaults: politeness-floor delay, no dry-run, additive mode', () => {
+    const o = parseRefreshArgs([]);
+    expect(o.delayMs).toBe(REQUEST_DELAY_MS);
+    expect(o.dryRun).toBe(false);
+    expect(o.refresh).toBe(false);
+  });
+
+  it('rejects a non-numeric --delay-ms instead of silently disabling pacing', () => {
+    expect(() => parseRefreshArgs(['--delay-ms', 'abc'])).toThrow(/--delay-ms/);
+  });
+
+  it('rejects --delay-ms with a missing value (must not consume the next flag)', () => {
+    expect(() => parseRefreshArgs(['--delay-ms'])).toThrow(/--delay-ms/);
+    expect(() => parseRefreshArgs(['--delay-ms', '--refresh'])).toThrow(/--delay-ms/);
+  });
+
+  it('rejects trailing-garbage numerics that parseInt would silently truncate', () => {
+    expect(() => parseRefreshArgs(['--limit', '500abc'])).toThrow(/--limit/);
+  });
+
+  it('enforces the politeness floor', () => {
+    expect(() => parseRefreshArgs(['--delay-ms', '100'])).toThrow(/politeness floor/);
+  });
+
+  it('enforces the politeness floor for --dry-run too — dry runs still fetch live sitemap pages', () => {
+    expect(() => parseRefreshArgs(['--delay-ms', '100', '--dry-run'])).toThrow(/politeness floor/);
+  });
+
+  it('accepts a delay at or above the floor', () => {
+    expect(parseRefreshArgs(['--delay-ms', '2500']).delayMs).toBe(2500);
+    expect(parseRefreshArgs(['--delay-ms', String(REQUEST_DELAY_MS)]).delayMs).toBe(REQUEST_DELAY_MS);
+  });
+
+  it('validates every numeric flag', () => {
+    expect(() => parseRefreshArgs(['--limit', 'x'])).toThrow(/--limit/);
+    expect(() => parseRefreshArgs(['--year-start', 'x'])).toThrow(/--year-start/);
+    expect(() => parseRefreshArgs(['--year-end', 'x'])).toThrow(/--year-end/);
+    expect(() => parseRefreshArgs(['--max-pages', 'x'])).toThrow(/--max-pages/);
+    expect(() => parseRefreshArgs(['--limit'])).toThrow(/--limit/);
+  });
+
+  it('still rejects unknown arguments', () => {
+    expect(() => parseRefreshArgs(['--frobnicate'])).toThrow(/Unknown argument/);
+  });
+});
+
+describe('parseRefreshArgs — --skip-stamped-since', () => {
+  it('accepts full ISO-8601 UTC and normalizes to millisecond precision for exact lexicographic compare with toISOString stamps', () => {
+    const o = parseRefreshArgs(['--refresh', '--skip-stamped-since', '2026-06-10T20:22:27Z']);
+    expect(o.skipStampedSince).toBe('2026-06-10T20:22:27.000Z');
+    const oMs = parseRefreshArgs(['--refresh', '--skip-stamped-since', '2026-06-10T20:22:27.792Z']);
+    expect(oMs.skipStampedSince).toBe('2026-06-10T20:22:27.792Z');
+  });
+
+  it('rejects a missing value instead of silently no-opping the resume lever', () => {
+    expect(() => parseRefreshArgs(['--refresh', '--skip-stamped-since'])).toThrow(/--skip-stamped-since/);
+    expect(() => parseRefreshArgs(['--skip-stamped-since', '--refresh'])).toThrow(/--skip-stamped-since/);
+  });
+
+  it('rejects date-only values — lexicographic compare would silently shift the skip boundary', () => {
+    expect(() => parseRefreshArgs(['--skip-stamped-since', '2026-06-10'])).toThrow(/ISO-8601 UTC/);
+  });
+
+  it('rejects offset-bearing timestamps — stamps are UTC Z, an offset shifts the boundary', () => {
+    expect(() => parseRefreshArgs(['--skip-stamped-since', '2026-06-10T20:22:27+02:00'])).toThrow(
+      /ISO-8601 UTC/,
+    );
+  });
+
+  it('rejects shape-valid but impossible timestamps', () => {
+    expect(() => parseRefreshArgs(['--skip-stamped-since', '2026-13-99T99:99:99Z'])).toThrow(
+      /--skip-stamped-since/,
+    );
+  });
+
+  it('rejects typo garbage', () => {
+    expect(() => parseRefreshArgs(['--skip-stamped-since', '2026-06-10T2O:22:27Z'])).toThrow(
+      /--skip-stamped-since/,
+    );
+  });
+});

--- a/tests/ingest/refresh-cli.test.ts
+++ b/tests/ingest/refresh-cli.test.ts
@@ -92,3 +92,20 @@ describe('parseRefreshArgs — --skip-stamped-since', () => {
     );
   });
 });
+
+describe('positive-integer flags (PR #90 round 3)', () => {
+  // --limit 0 / negative silently DISABLED the limit (applyLimit treats
+  // falsy/<=0 as "no limit") while the banner printed "Limit: 0".
+  it.each([
+    ['--limit', '0'],
+    ['--limit', '-100'],
+    ['--max-pages', '0'],
+    ['--max-pages', '-1'],
+  ])('rejects %s %s loudly', (flag, value) => {
+    expect(() => parseRefreshArgs([flag, value])).toThrow(/positive/i);
+  });
+
+  it('still accepts positive values', () => {
+    expect(parseRefreshArgs(['--limit', '5']).limit).toBe(5);
+  });
+});

--- a/tests/ingest/refresh-policy.test.ts
+++ b/tests/ingest/refresh-policy.test.ts
@@ -1,0 +1,126 @@
+/**
+ * Version-keyed refresh decisions (issue #89, ported from Dutch-law-mcp#117).
+ *
+ * Danish reality (measured 2026-06-10): the sitemap lastmod does NOT track
+ * status/metadata changes (2019/241 was historic-marked 2019-07-04 and
+ * EndDate-stamped in 2026, lastmod still 2019-03-16), and the harvest API
+ * only serves a 10-day window. There is therefore NO cheap upstream signal
+ * that can PROVE a stored seed current. The policy refetches whenever
+ * freshness is unproven; the only skips are exact: additive-mode skips and
+ * same-run resume stamps.
+ */
+import { describe, it, expect } from 'vitest';
+import { decideFetch, stampIngestMeta } from '../../scripts/lib/refresh-policy.js';
+
+const NOW = '2026-06-11T03:00:00Z';
+const TODAY = '2026-06-11';
+
+const stamped = {
+  retrieved_at: '2026-06-11T01:00:00Z',
+  accession: 'A20190024129',
+  document_id: 'CK002013',
+  unique_document_id: '207970',
+  upstream_status: 'Historic',
+  start_date: '2019-03-16',
+  end_date: '2025-12-23',
+  historic_marked: '2019-07-04',
+  seed_status: 'repealed' as const,
+};
+
+describe('decideFetch', () => {
+  it('fetches documents we do not hold', () => {
+    expect(decideFetch({ seedExists: false, refresh: false, today: TODAY })).toBe('fetch_new');
+    expect(decideFetch({ seedExists: false, refresh: true, today: TODAY })).toBe('fetch_new');
+  });
+
+  it('additive mode (no --refresh) skips existing seeds, exactly as before', () => {
+    expect(decideFetch({ seedExists: true, refresh: false, today: TODAY })).toBe('skip_existing');
+  });
+
+  it('unstamped seeds self-heal unconditionally — the whole 2026-02-15 corpus', () => {
+    expect(
+      decideFetch({ seedExists: true, refresh: true, existingMeta: null, today: TODAY }),
+    ).toBe('refetch_unknown');
+    expect(
+      decideFetch({ seedExists: true, refresh: true, existingMeta: undefined, today: TODAY }),
+    ).toBe('refetch_unknown');
+  });
+
+  it('same-run resume: stamp at/after skipStampedSince proves this run already refreshed it', () => {
+    expect(
+      decideFetch({
+        seedExists: true,
+        refresh: true,
+        existingMeta: stamped,
+        skipStampedSince: '2026-06-11T00:00:00Z',
+        today: TODAY,
+      }),
+    ).toBe('skip_current');
+  });
+
+  it('a stamp from before skipStampedSince does NOT prove currency', () => {
+    expect(
+      decideFetch({
+        seedExists: true,
+        refresh: true,
+        existingMeta: stamped,
+        skipStampedSince: '2026-06-11T02:00:00Z',
+        today: TODAY,
+      }),
+    ).toBe('refetch_unknown');
+  });
+
+  it('stamped in_force whose EndDate has since passed is refetch_changed', () => {
+    expect(
+      decideFetch({
+        seedExists: true,
+        refresh: true,
+        existingMeta: {
+          ...stamped,
+          retrieved_at: '2026-03-01T00:00:00Z',
+          upstream_status: 'Valid',
+          seed_status: 'in_force',
+          end_date: '2026-05-01',
+        },
+        today: TODAY,
+      }),
+    ).toBe('refetch_changed');
+  });
+
+  it('without skipStampedSince a stamp alone cannot prove currency — refetch', () => {
+    expect(
+      decideFetch({ seedExists: true, refresh: true, existingMeta: stamped, today: TODAY }),
+    ).toBe('refetch_unknown');
+  });
+});
+
+describe('stampIngestMeta', () => {
+  it('writes one canonical _ingest shape', () => {
+    const out = stampIngestMeta(
+      { id: '2019:241', provisions: [] },
+      {
+        accession: 'A20190024129',
+        document_id: 'CK002013',
+        unique_document_id: '207970',
+        upstream_status: 'Historic',
+        start_date: '2019-03-16',
+        end_date: '2025-12-23',
+        historic_marked: '2019-07-04',
+      },
+      'repealed',
+      NOW,
+    );
+    expect(out._ingest).toEqual({
+      retrieved_at: NOW,
+      accession: 'A20190024129',
+      document_id: 'CK002013',
+      unique_document_id: '207970',
+      upstream_status: 'Historic',
+      start_date: '2019-03-16',
+      end_date: '2025-12-23',
+      historic_marked: '2019-07-04',
+      seed_status: 'repealed',
+    });
+    expect(out.id).toBe('2019:241');
+  });
+});

--- a/tests/ingest/refresh-worklist.test.ts
+++ b/tests/ingest/refresh-worklist.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Worklist construction + fail-loud run summary (issue #89).
+ *
+ * The old bulk runner iterated sitemap entries only — 656 held seeds are
+ * absent from today's sitemap and would silently never be revisited. The
+ * refresh worklist is the UNION of sitemap docs and held seeds. The run
+ * summary exits non-zero on any failure and enumerates failures and
+ * gone-upstream findings instead of burying them in a log.
+ */
+import { describe, it, expect } from 'vitest';
+import { buildWorklist, summarizeRun } from '../../scripts/lib/refresh-worklist.js';
+
+describe('buildWorklist', () => {
+  it('unions sitemap entries with held seeds and reconstructs URLs for seed-only docs', () => {
+    const work = buildWorklist({
+      sitemapEntries: [
+        { id: '2026_510', url: 'https://retsinformation.dk/eli/lta/2026/510', lastmod: '2026-06-09' },
+        { id: '2019_241', url: 'https://retsinformation.dk/eli/lta/2019/241', lastmod: '2019-03-16' },
+      ],
+      existingSeedIds: ['2019_241', '2007_1016'],
+    });
+    const byId = new Map(work.map((w) => [w.id, w]));
+    expect(byId.size).toBe(3);
+    expect(byId.get('2026_510')?.seedExists).toBe(false);
+    expect(byId.get('2019_241')?.seedExists).toBe(true);
+    const seedOnly = byId.get('2007_1016');
+    expect(seedOnly?.seedExists).toBe(true);
+    expect(seedOnly?.inSitemap).toBe(false);
+    expect(seedOnly?.xmlUrl).toBe('https://www.retsinformation.dk/eli/lta/2007/1016/xml');
+  });
+
+  it('normalizes sitemap document URLs to the canonical https://www host and /xml payload', () => {
+    const work = buildWorklist({
+      sitemapEntries: [
+        { id: '2026_510', url: 'https://retsinformation.dk/eli/lta/2026/510', lastmod: null },
+      ],
+      existingSeedIds: [],
+    });
+    expect(work[0].xmlUrl).toBe('https://www.retsinformation.dk/eli/lta/2026/510/xml');
+  });
+});
+
+describe('summarizeRun', () => {
+  const empty = {
+    total: 10,
+    fetched: 8,
+    skipped: 2,
+    failed: [] as Array<{ id: string; error: string }>,
+    goneUpstream: [] as Array<{ id: string; httpStatus: number }>,
+  };
+
+  it('exit 0 on a clean run', () => {
+    expect(summarizeRun(empty).exitCode).toBe(0);
+  });
+
+  it('exit 2 on partial failure — a partial sweep must never look complete', () => {
+    const s = summarizeRun({ ...empty, failed: [{ id: '2019_241', error: 'HTTP 503 after retries' }] });
+    expect(s.exitCode).toBe(2);
+    expect(s.lines.join('\n')).toContain('2019_241');
+  });
+
+  it('gone-upstream findings are enumerated but are not failures', () => {
+    const s = summarizeRun({ ...empty, goneUpstream: [{ id: '1993_812', httpStatus: 404 }] });
+    expect(s.exitCode).toBe(0);
+    expect(s.lines.join('\n')).toContain('1993_812');
+    expect(s.lines.join('\n')).toMatch(/gone/i);
+  });
+});

--- a/tests/ingest/refresh-worklist.test.ts
+++ b/tests/ingest/refresh-worklist.test.ts
@@ -173,3 +173,47 @@ describe('applyLimit (PR #90 round 2)', () => {
     expect(applyLimit(decided, 0)).toEqual(decided);
   });
 });
+
+describe('readHeldSeedId — error discrimination (PR #90 round 3)', () => {
+  // Self-heal (null) is for missing/torn/id-less seeds ONLY. A transient fs
+  // error (EACCES/EIO/EMFILE) is none of those: returning null would disable
+  // the identity gate AND authorize overwriting the held good seed.
+  it('returns null for a missing seed (ENOENT — the never-held case)', () => {
+    expect(readHeldSeedId(path.join(tmpDir(), 'nope.json'))).toBeNull();
+  });
+
+  it('returns null for torn JSON (the documented self-heal class)', () => {
+    const dir = tmpDir();
+    const p = path.join(dir, 'torn.json');
+    fs.writeFileSync(p, '{"id": "AL0005');
+    expect(readHeldSeedId(p)).toBeNull();
+  });
+
+  it('THROWS on non-ENOENT fs errors instead of disabling the identity gate', () => {
+    const dir = tmpDir();
+    const p = path.join(dir, 'locked.json');
+    fs.writeFileSync(p, JSON.stringify({ id: 'AL000501' }));
+    fs.chmodSync(p, 0o000);
+    try {
+      expect(() => readHeldSeedId(p)).toThrow(/EACCES|permission/i);
+    } finally {
+      fs.chmodSync(p, 0o644);
+    }
+  });
+});
+
+describe('quarantineGoneSeed — evidence preservation (PR #90 round 3)', () => {
+  it('never overwrites an existing quarantined file — uniquifies instead', () => {
+    const dir = tmpDir();
+    const qdir = path.join(dir, 'seed-gone');
+    const seed = path.join(dir, '1993_812.json');
+    fs.mkdirSync(qdir, { recursive: true });
+    fs.writeFileSync(path.join(qdir, '1993_812.json'), '{"id":"run-1 evidence"}');
+    fs.writeFileSync(seed, '{"id":"run-2 copy"}');
+    const dest = quarantineGoneSeed(seed, qdir);
+    expect(dest).not.toBeNull();
+    expect(dest).not.toBe(path.join(qdir, '1993_812.json'));
+    expect(fs.readFileSync(path.join(qdir, '1993_812.json'), 'utf-8')).toContain('run-1 evidence');
+    expect(fs.readFileSync(dest as string, 'utf-8')).toContain('run-2 copy');
+  });
+});

--- a/tests/ingest/refresh-worklist.test.ts
+++ b/tests/ingest/refresh-worklist.test.ts
@@ -8,7 +8,16 @@
  * gone-upstream findings instead of burying them in a log.
  */
 import { describe, it, expect } from 'vitest';
-import { buildWorklist, summarizeRun } from '../../scripts/lib/refresh-worklist.js';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import {
+  applyLimit,
+  buildWorklist,
+  quarantineGoneSeed,
+  readHeldSeedId,
+  summarizeRun,
+} from '../../scripts/lib/refresh-worklist.js';
 
 describe('buildWorklist', () => {
   it('unions sitemap entries with held seeds and reconstructs URLs for seed-only docs', () => {
@@ -60,9 +69,107 @@ describe('summarizeRun', () => {
   });
 
   it('gone-upstream findings are enumerated but are not failures', () => {
-    const s = summarizeRun({ ...empty, goneUpstream: [{ id: '1993_812', httpStatus: 404 }] });
+    const s = summarizeRun({
+      ...empty,
+      goneUpstream: [{ id: '1993_812', httpStatus: 404, quarantined: true }],
+    });
     expect(s.exitCode).toBe(0);
     expect(s.lines.join('\n')).toContain('1993_812');
     expect(s.lines.join('\n')).toMatch(/gone/i);
+  });
+
+  it('enumerates the quarantine action per gone seed (PR #90 round 2)', () => {
+    const s = summarizeRun({
+      ...empty,
+      goneUpstream: [
+        { id: '1993_812', httpStatus: 404, quarantined: true },
+        { id: '2026_999', httpStatus: 410, quarantined: false },
+      ],
+    });
+    expect(s.exitCode).toBe(0); // gone-only runs still exit 0
+    const text = s.lines.join('\n');
+    expect(text).toMatch(/1993_812.*quarantined/i);
+    expect(text).toMatch(/2026_999.*no held seed/i);
+  });
+});
+
+function tmpDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'dk-worklist-lib-test-'));
+}
+
+describe('quarantineGoneSeed (PR #90 round 2, Dutch 976c0ef pattern)', () => {
+  it('renames the held seed into the quarantine dir — preserved, not deleted, not served', () => {
+    const dir = tmpDir();
+    const seedPath = path.join(dir, 'seed', '1993_812.json');
+    fs.mkdirSync(path.dirname(seedPath), { recursive: true });
+    fs.writeFileSync(seedPath, '{"id":"1993:812"}\n', 'utf-8');
+    const quarantineDir = path.join(dir, 'seed-gone');
+
+    const dest = quarantineGoneSeed(seedPath, quarantineDir);
+
+    expect(dest).toBe(path.join(quarantineDir, '1993_812.json'));
+    expect(fs.existsSync(seedPath)).toBe(false);
+    expect(fs.readFileSync(dest as string, 'utf-8')).toBe('{"id":"1993:812"}\n');
+  });
+
+  it('returns null when there is no held seed to quarantine', () => {
+    const dir = tmpDir();
+    expect(quarantineGoneSeed(path.join(dir, 'absent.json'), path.join(dir, 'q'))).toBeNull();
+  });
+});
+
+describe('readHeldSeedId (PR #90 round 2)', () => {
+  it('returns the id we already serve — the identity gate compares against THIS, never a re-derived format', () => {
+    const dir = tmpDir();
+    const p = path.join(dir, '1852_11000.json');
+    fs.writeFileSync(p, JSON.stringify({ id: 'AL000501', status: 'in_force' }), 'utf-8');
+    expect(readHeldSeedId(p)).toBe('AL000501');
+  });
+
+  it('returns null for missing, torn, or id-less seeds — no held identity, served id becomes the identity', () => {
+    const dir = tmpDir();
+    expect(readHeldSeedId(path.join(dir, 'absent.json'))).toBeNull();
+    const torn = path.join(dir, 'torn.json');
+    fs.writeFileSync(torn, '{"id":"1993:8', 'utf-8');
+    expect(readHeldSeedId(torn)).toBeNull();
+    const idless = path.join(dir, 'idless.json');
+    fs.writeFileSync(idless, '{"provisions":[]}', 'utf-8');
+    expect(readHeldSeedId(idless)).toBeNull();
+  });
+});
+
+describe('applyLimit (PR #90 round 2)', () => {
+  type D = { id: string; decision: 'fetch_new' | 'refetch_unknown' | 'skip_current' | 'skip_existing' };
+  const d = (id: string, decision: D['decision']): D => ({ id, decision });
+
+  it('budgets only items that actually fetch — skips pass through free so chunked resumes advance', () => {
+    const decided = [
+      d('a', 'skip_current'),
+      d('b', 'refetch_unknown'),
+      d('c', 'skip_existing'),
+      d('d', 'fetch_new'),
+      d('e', 'refetch_unknown'), // over budget
+    ];
+    const queue = applyLimit(decided, 2);
+    expect(queue.map((q) => q.id)).toEqual(['a', 'b', 'c', 'd']);
+  });
+
+  it('a fully-stamped prefix no longer starves the budget', () => {
+    // Regression: after chunk 1 stamped the first N items, every later
+    // --limit N invocation processed only skips and reported fetched=0
+    // while the sweep never advanced.
+    const decided = [
+      d('done1', 'skip_current'),
+      d('done2', 'skip_current'),
+      d('next1', 'refetch_unknown'),
+    ];
+    const queue = applyLimit(decided, 2);
+    expect(queue.map((q) => q.id)).toContain('next1');
+  });
+
+  it('no limit returns the full worklist', () => {
+    const decided = [d('a', 'fetch_new'), d('b', 'skip_current')];
+    expect(applyLimit(decided, undefined)).toEqual(decided);
+    expect(applyLimit(decided, 0)).toEqual(decided);
   });
 });

--- a/tests/ingest/run-report.test.ts
+++ b/tests/ingest/run-report.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Durable run records (PR #90 round 2).
+ *
+ * The killed 51h sweep left NO machine-readable record of its start time —
+ * the exact --skip-stamped-since resume cutoff — because the report was
+ * written only at successful completion and its default path was keyed by
+ * DATE only (same-day rerun overwrites it). Required: a run-start marker
+ * written at startup, run-stamped (not date-only) report paths, and a
+ * partial report on SIGINT/SIGTERM.
+ */
+import { describe, it, expect } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import {
+  runStamp,
+  buildReportPath,
+  writeRunMarker,
+  writeReport,
+  makeInterruptHandler,
+} from '../../scripts/lib/run-report.js';
+
+const STARTED = '2026-06-10T20:22:27.792Z';
+
+function tmpDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'dk-report-test-'));
+}
+
+describe('runStamp', () => {
+  it('is filesystem-safe and second+millisecond precise', () => {
+    expect(runStamp(STARTED)).toBe('2026-06-10T20-22-27-792Z');
+    expect(runStamp(STARTED)).not.toMatch(/[:.]/);
+  });
+});
+
+describe('buildReportPath', () => {
+  it('stamps the full run start, not just the date — same-day reruns must not overwrite', () => {
+    const p = buildReportPath('/reports', STARTED);
+    expect(p).toBe('/reports/ingest-refresh-2026-06-10T20-22-27-792Z.json');
+    const later = buildReportPath('/reports', '2026-06-10T21:00:00.000Z');
+    expect(later).not.toBe(p);
+  });
+
+  it('respects an explicit --report override', () => {
+    expect(buildReportPath('/reports', STARTED, '/tmp/custom.json')).toBe('/tmp/custom.json');
+  });
+});
+
+describe('writeRunMarker', () => {
+  it('writes a run-stamped marker at startup so an interrupted run keeps its resume cutoff', () => {
+    const dir = tmpDir();
+    const marker = writeRunMarker(dir, {
+      run_started_at: STARTED,
+      mode: 'refresh',
+      skip_stamped_since: null,
+    });
+    expect(path.basename(marker)).toBe('run-started-2026-06-10T20-22-27-792Z.json');
+    const parsed = JSON.parse(fs.readFileSync(marker, 'utf-8'));
+    expect(parsed.run_started_at).toBe(STARTED);
+    expect(parsed.mode).toBe('refresh');
+  });
+
+  it('creates the report directory if missing', () => {
+    const dir = path.join(tmpDir(), 'reports');
+    const marker = writeRunMarker(dir, { run_started_at: STARTED });
+    expect(fs.existsSync(marker)).toBe(true);
+  });
+});
+
+describe('writeReport', () => {
+  it('writes parseable JSON with a trailing newline', () => {
+    const dir = tmpDir();
+    const p = path.join(dir, 'r.json');
+    writeReport(p, { run_started_at: STARTED, stats: { fetched: 1 } });
+    const raw = fs.readFileSync(p, 'utf-8');
+    expect(raw.endsWith('\n')).toBe(true);
+    expect(JSON.parse(raw).stats.fetched).toBe(1);
+  });
+});
+
+describe('makeInterruptHandler', () => {
+  it('writes a partial report marked interrupted and exits with the conventional signal code', () => {
+    const dir = tmpDir();
+    const reportPath = path.join(dir, 'r.json');
+    const exits: number[] = [];
+    const handler = makeInterruptHandler({
+      reportPath,
+      payload: () => ({ run_started_at: STARTED, stats: { fetched: 42 } }),
+      exitFn: (code) => {
+        exits.push(code);
+      },
+    });
+
+    handler('SIGTERM');
+    const parsed = JSON.parse(fs.readFileSync(reportPath, 'utf-8'));
+    expect(parsed.interrupted_by).toBe('SIGTERM');
+    expect(parsed.partial).toBe(true);
+    expect(parsed.stats.fetched).toBe(42);
+    expect(exits).toEqual([143]);
+
+    handler('SIGINT');
+    expect(exits).toEqual([143, 130]);
+    expect(JSON.parse(fs.readFileSync(reportPath, 'utf-8')).interrupted_by).toBe('SIGINT');
+  });
+
+  it('still exits if the report write fails — a broken disk must not hang shutdown', () => {
+    const exits: number[] = [];
+    const logs: string[] = [];
+    // Parent "directory" is a FILE: mkdir/open fail with ENOTDIR — a real
+    // write failure, not a missing dir that writeReport would just create.
+    const notADir = path.join(tmpDir(), 'not-a-dir');
+    fs.writeFileSync(notADir, 'x', 'utf-8');
+    const handler = makeInterruptHandler({
+      reportPath: path.join(notADir, 'r.json'),
+      payload: () => ({}),
+      exitFn: (code) => {
+        exits.push(code);
+      },
+      log: (line) => {
+        logs.push(line);
+      },
+    });
+    handler('SIGINT');
+    expect(exits).toEqual([130]);
+    expect(logs.join('\n')).toMatch(/failed to write partial report/);
+  });
+});

--- a/tests/ingest/sitemap.test.ts
+++ b/tests/ingest/sitemap.test.ts
@@ -1,0 +1,140 @@
+/**
+ * Sitemap parsing robustness + sanity floor (PR #90 round 2).
+ *
+ * The old <url> regex required the exact child sequence loc[,lastmod]: any
+ * standard optional child (<changefreq>, <priority>) or reordering yielded
+ * ZERO entries, and the union-with-held-seeds worklist then silently degraded
+ * to a seeds-only run that exits 0 — dropping every never-held fetch_new
+ * document. Parsing must be order-independent, and a sitemap that yields zero
+ * pages or zero entries must FAIL the run.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  extractUrlEntries,
+  extractSitemapLocs,
+  collectSitemapEntries,
+  SitemapSanityError,
+} from '../../scripts/lib/sitemap.js';
+
+describe('extractUrlEntries', () => {
+  it('parses the current upstream shape (loc + lastmod)', () => {
+    const xml = `<urlset><url><loc>https://retsinformation.dk/eli/lta/2019/241</loc><lastmod>2019-03-16</lastmod></url></urlset>`;
+    expect(extractUrlEntries(xml)).toEqual([
+      { loc: 'https://retsinformation.dk/eli/lta/2019/241', lastmod: '2019-03-16' },
+    ]);
+  });
+
+  it('tolerates standard optional children (changefreq, priority)', () => {
+    const xml = `<url><loc>https://x.dk/eli/lta/2019/241</loc><lastmod>2019-03-16</lastmod><changefreq>monthly</changefreq><priority>0.5</priority></url>`;
+    expect(extractUrlEntries(xml)).toEqual([
+      { loc: 'https://x.dk/eli/lta/2019/241', lastmod: '2019-03-16' },
+    ]);
+  });
+
+  it('tolerates child reordering (lastmod before loc)', () => {
+    const xml = `<url><lastmod>2019-03-16</lastmod><loc>https://x.dk/eli/lta/2019/241</loc></url>`;
+    expect(extractUrlEntries(xml)).toEqual([
+      { loc: 'https://x.dk/eli/lta/2019/241', lastmod: '2019-03-16' },
+    ]);
+  });
+
+  it('handles a missing lastmod and multiple url blocks', () => {
+    const xml = `<urlset>
+      <url><loc>https://x.dk/a</loc></url>
+      <url><priority>0.1</priority><loc>https://x.dk/b</loc><lastmod>2020-01-01</lastmod></url>
+    </urlset>`;
+    expect(extractUrlEntries(xml)).toEqual([
+      { loc: 'https://x.dk/a', lastmod: undefined },
+      { loc: 'https://x.dk/b', lastmod: '2020-01-01' },
+    ]);
+  });
+});
+
+function indexXml(pages: string[]): string {
+  return `<sitemapindex>${pages.map((p) => `<sitemap><loc>${p}</loc></sitemap>`).join('')}</sitemapindex>`;
+}
+
+function pageXml(entries: Array<{ loc: string; lastmod?: string }>): string {
+  return `<urlset>${entries
+    .map((e) => `<url><loc>${e.loc}</loc>${e.lastmod ? `<lastmod>${e.lastmod}</lastmod>` : ''}<priority>0.5</priority></url>`)
+    .join('')}</urlset>`;
+}
+
+function fakeFetchText(byUrl: Record<string, string>): (url: string) => Promise<string> {
+  return async (url: string) => {
+    const body = byUrl[url];
+    if (body === undefined) throw new Error(`unexpected fetch: ${url}`);
+    return body;
+  };
+}
+
+const INDEX = 'https://www.retsinformation.dk/sitemap.xml';
+
+describe('collectSitemapEntries', () => {
+  const base = { indexUrl: INDEX, delayMs: 0, sleepFn: async () => {} };
+
+  it('collects /eli/lta documents across pages and keeps the newest lastmod per id', async () => {
+    const fetchText = fakeFetchText({
+      [INDEX]: indexXml([`${INDEX}?page=1`, `${INDEX}?page=2`]),
+      [`${INDEX}?page=1`]: pageXml([
+        { loc: 'https://retsinformation.dk/eli/lta/2019/241', lastmod: '2019-03-16' },
+        { loc: 'https://retsinformation.dk/eli/lta/2026/510' },
+      ]),
+      [`${INDEX}?page=2`]: pageXml([
+        { loc: 'https://retsinformation.dk/eli/lta/2019/241', lastmod: '2026-01-01' },
+        { loc: 'https://retsinformation.dk/about', lastmod: '2026-01-01' }, // non-document: ignored
+      ]),
+    });
+    const entries = await collectSitemapEntries({ ...base, fetchText });
+    const byId = new Map(entries.map((e) => [e.id, e]));
+    expect(byId.size).toBe(2);
+    expect(byId.get('2019_241')?.lastmod).toBe('2026-01-01');
+    expect(byId.get('2026_510')?.lastmod).toBeNull();
+  });
+
+  it('FAILS the run when the index yields zero sitemap pages — never degrade to seeds-only', async () => {
+    const fetchText = fakeFetchText({
+      [INDEX]: '<html>maintenance</html>',
+    });
+    await expect(collectSitemapEntries({ ...base, fetchText })).rejects.toThrow(SitemapSanityError);
+  });
+
+  it('FAILS the run when the pages yield zero document entries', async () => {
+    const fetchText = fakeFetchText({
+      [INDEX]: indexXml([`${INDEX}?page=1`]),
+      [`${INDEX}?page=1`]: '<urlset></urlset>',
+    });
+    await expect(collectSitemapEntries({ ...base, fetchText })).rejects.toThrow(SitemapSanityError);
+  });
+
+  it('applies year bounds', async () => {
+    const fetchText = fakeFetchText({
+      [INDEX]: indexXml([`${INDEX}?page=1`]),
+      [`${INDEX}?page=1`]: pageXml([
+        { loc: 'https://retsinformation.dk/eli/lta/1999/1' },
+        { loc: 'https://retsinformation.dk/eli/lta/2020/2' },
+      ]),
+    });
+    const entries = await collectSitemapEntries({ ...base, fetchText, yearStart: 2000 });
+    expect(entries.map((e) => e.id)).toEqual(['2020_2']);
+  });
+
+  it('respects maxPages', async () => {
+    const fetchText = fakeFetchText({
+      [INDEX]: indexXml([`${INDEX}?page=1`, `${INDEX}?page=2`]),
+      [`${INDEX}?page=1`]: pageXml([{ loc: 'https://retsinformation.dk/eli/lta/2020/2' }]),
+      // page=2 intentionally absent: fetching it would throw
+    });
+    const entries = await collectSitemapEntries({ ...base, fetchText, maxPages: 1 });
+    expect(entries.map((e) => e.id)).toEqual(['2020_2']);
+  });
+});
+
+describe('extractSitemapLocs', () => {
+  it('extracts loc values', () => {
+    expect(extractSitemapLocs(indexXml(['https://a', 'https://b']))).toEqual([
+      'https://a',
+      'https://b',
+    ]);
+  });
+});

--- a/tests/ingest/version-identity.test.ts
+++ b/tests/ingest/version-identity.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Version-identity extraction + explicit status mapping (issue #89).
+ *
+ * The 2026-02-15 sweep mapped upstream `<Status>Historic</Status>` to
+ * `in_force` because the old inferStatus() silently defaulted every
+ * unrecognized status text to in_force. 22,182 of 62,762 seeds carry a
+ * fetch-time historic doc-type marker yet claim to be current law.
+ * Mapping must be explicit; unknown vocabulary must THROW, never default.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  extractVersionIdentity,
+  mapSeedStatus,
+  UnknownUpstreamStatusError,
+} from '../../scripts/lib/version-identity.js';
+
+const TODAY = '2026-06-10';
+
+describe('extractVersionIdentity', () => {
+  it('extracts the served consolidation identity from a parsed Meta node', () => {
+    const meta = {
+      DocumentType: 'LBK H#LOKDOK03',
+      AccessionNumber: 'A20190024129',
+      DocumentId: 'CK002013',
+      UniqueDocumentId: 207970,
+      StartDate: { '#text': '2019-03-16', REFid: 'submit_1' },
+      EndDate: { '#text': '2025-12-23', REFid: 'submit_1' },
+      Status: 'Historic',
+      DateOfHistoricMark: '2019-07-04',
+      Year: 2019,
+      Number: 241,
+    };
+    const id = extractVersionIdentity(meta);
+    expect(id.accession).toBe('A20190024129');
+    expect(id.document_id).toBe('CK002013');
+    expect(id.unique_document_id).toBe('207970');
+    expect(id.upstream_status).toBe('Historic');
+    expect(id.start_date).toBe('2019-03-16');
+    expect(id.end_date).toBe('2025-12-23');
+    expect(id.historic_marked).toBe('2019-07-04');
+  });
+
+  it('returns nulls for absent fields instead of inventing values', () => {
+    const id = extractVersionIdentity({});
+    expect(id.accession).toBeNull();
+    expect(id.end_date).toBeNull();
+    expect(id.upstream_status).toBeNull();
+  });
+});
+
+describe('mapSeedStatus', () => {
+  const base = {
+    accession: 'A20190024129',
+    document_id: 'CK002013',
+    unique_document_id: '207970',
+    upstream_status: 'Valid',
+    start_date: '2019-03-16',
+    end_date: null,
+    historic_marked: null,
+  };
+
+  it('maps Historic to repealed (the 2026-02-15 sweep defect)', () => {
+    expect(mapSeedStatus({ ...base, upstream_status: 'Historic' }, TODAY)).toBe('repealed');
+  });
+
+  it('maps Historisk (Danish) to repealed', () => {
+    expect(mapSeedStatus({ ...base, upstream_status: 'Historisk' }, TODAY)).toBe('repealed');
+  });
+
+  it('maps Valid / Gældende to in_force', () => {
+    expect(mapSeedStatus({ ...base, upstream_status: 'Valid' }, TODAY)).toBe('in_force');
+    expect(mapSeedStatus({ ...base, upstream_status: 'Gældende' }, TODAY)).toBe('in_force');
+  });
+
+  it('a past EndDate does NOT override Valid — EndDate is the amended-through marker, not supersession (verified live: kursgevinstloven LBK 2025/1176, Valid, EndDate 2026-01-20, timeline isHistoric=false)', () => {
+    expect(
+      mapSeedStatus({ ...base, upstream_status: 'Valid', end_date: '2026-01-20' }, TODAY),
+    ).toBe('in_force');
+  });
+
+  it('a future StartDate on a Valid document means not_yet_in_force', () => {
+    expect(
+      mapSeedStatus({ ...base, upstream_status: 'Valid', start_date: '2026-09-01' }, TODAY),
+    ).toBe('not_yet_in_force');
+  });
+
+  it('THROWS on unknown status vocabulary — never silently defaults to in_force', () => {
+    expect(() => mapSeedStatus({ ...base, upstream_status: 'Bortfaldet' }, TODAY)).toThrow(
+      UnknownUpstreamStatusError,
+    );
+  });
+
+  it('THROWS when status is missing — dates alone prove nothing', () => {
+    expect(() => mapSeedStatus({ ...base, upstream_status: null }, TODAY)).toThrow(
+      UnknownUpstreamStatusError,
+    );
+    expect(() =>
+      mapSeedStatus({ ...base, upstream_status: null, end_date: '2020-01-01' }, TODAY),
+    ).toThrow(UnknownUpstreamStatusError);
+  });
+});

--- a/tests/ingest/version-identity.test.ts
+++ b/tests/ingest/version-identity.test.ts
@@ -90,6 +90,20 @@ describe('mapSeedStatus', () => {
     );
   });
 
+  it('does not pre-authorize guessed vocabulary never observed upstream (PR #90 round 2)', () => {
+    // Observed live (2026-06-10): Valid / Historic. 'gallende' is not a Danish
+    // word and 'gaeldende' (ASCII fold) has never been served — accepting them
+    // is the same silent-default class issue #89 removed, moved into the
+    // accept-set. Unknown must THROW so the operator extends the mapping
+    // deliberately.
+    expect(() => mapSeedStatus({ ...base, upstream_status: 'Gallende' }, TODAY)).toThrow(
+      UnknownUpstreamStatusError,
+    );
+    expect(() => mapSeedStatus({ ...base, upstream_status: 'Gaeldende' }, TODAY)).toThrow(
+      UnknownUpstreamStatusError,
+    );
+  });
+
   it('THROWS when status is missing — dates alone prove nothing', () => {
     expect(() => mapSeedStatus({ ...base, upstream_status: null }, TODAY)).toThrow(
       UnknownUpstreamStatusError,


### PR DESCRIPTION
Fixes #89 — Dutch-law-mcp#119 defect class, Danish manifestation.

## What the audit proved (live, 2026-06-10)

**Stale-fraction screen — random n=100 seeds, served XML checked at 2s pacing:**

| Upstream state | Count | Meaning |
|---|---|---|
| `<Status>Historic</Status>` | **76** | superseded consolidations our corpus serves as `in_force` |
| `<Status>Valid</Status>` | 24 | genuinely current |

**76% of the corpus (95% CI ±8.4pp → ~42k–53k of 62,762 seeds) presents superseded law as current.** The local corpus records 62,761/62,762 seeds as `in_force`. The proven case from the issue (2019_241, miljøbeskyttelsesloven LBK) has been historic since **2019-07-04**.

Two code defects caused this:

1. `inferStatus()` silently defaulted every unrecognized status text — including `Historic` — to `in_force` (a no-silent-fallback violation).
2. `parseIsoDate()` only handled plain strings; attribute-carrying `<StartDate REFid=..>` / `<EndDate REFid=..>` parse to objects under fast-xml-parser and silently became `undefined`, so date evidence never fired either.

## Upstream findings (each verified live)

- `/eli/lta/{year}/{number}/xml` serves a **fixed document** (100/100 sampled URLs served the exact year/number requested — no version redirect). Currency is corpus-level in Denmark: each consolidation (LBK) is its own document; the served `<Status>` is the per-document truth signal.
- **`<EndDate>` is NOT supersession evidence.** It is the amended-through marker: kursgevinstloven LBK 2025/1176 serves `Valid` with `EndDate 2026-01-20` (past) and the site's own timeline API (`/api/document/{uniqueDocumentId}/timeline`) says `isHistoric: false` — it IS the current consolidation. Mapping `EndDate < today → repealed` would wrongly repeal current law (first draft of this PR did exactly that; caught by verification against the timeline API).
- **Sitemap `lastmod` does not track status/metadata changes**: 2019_241 was historic-marked 2019-07-04 and EndDate-stamped during 2026, yet its lastmod is still its publication date 2019-03-16. Only 272 of 62,350 sitemap entries have lastmod ≥ sweep date while ≥76% of the corpus is stale. lastmod can never prove currency (the Dutch already-pinned-old lesson, in sitemap form).
- **The harvest API (`api.retsinformation.dk/v1/Documents`) serves a 10-day window only** (swagger: date param "Skal ligge inden for de seneste 10 dage", 1 call/10s, open 03:00–23:45). Useless for reconstructing changes since 2026-02-15; right tool for daily incremental harvest going forward.
- The `LBK H`/`BEK H` doc-type codes are **not** a historic marker (they appear on Valid docs too — LexDania schema family), so no local screen can substitute for refetching: the only per-document truth test is the served `<Status>`.
- Sitemap ∪ seeds diff: **244 documents upstream that we do not hold** (234 published 2026, post-sweep) and **656 held seeds absent from today's sitemap** (absence is NOT gone-evidence; only 404/410 is).

## Strategy + math

There is no cheap upstream signal that can prove a stored seed current (lastmod unreliable, harvest window 10 days, no per-doc metadata endpoint). With ≥76% of the corpus needing repair anyway, the correct repair is a **full re-acquisition sweep**:

- Worklist = sitemap (62,350) ∪ held seeds (62,762) = **63,006 documents** (244 fetch_new + 62,762 refetch).
- Pacing: 2s start-to-start politeness floor + ~0.5s fetch ≈ 2.5s/doc → 63,006 × 2.5s ≈ 157,500s ≈ **≈44h unattended**.
- Bandwidth ≈ 9–10GB total at ~60KB/s average — gentle on upstream.
- New documents are fetched **first** (current law missing from the corpus is the most dangerous gap), then refreshes in id order, so an interrupted run + `--skip-stamped-since <run-start>` resume converges.
- Future refreshes stay honest: the policy refetches whenever freshness is unproven; cheap incremental freshness comes from the daily harvest API path (`npm run check-updates`), not from trusting stamps.

## The fix (ported from Dutch-law-mcp #117/#119/#120 to Danish idioms)

| Dutch reference | Danish port |
|---|---|
| `toestand.ts` (version parse/select) | `scripts/lib/version-identity.ts` — served-consolidation identity (Accession/DocumentId/UniqueDocumentId/Status/Start/End/HistoricMark) + **explicit** status mapping that THROWS on unknown vocabulary |
| `refresh-policy.ts` | `scripts/lib/refresh-policy.ts` — version-keyed decisions; unstamped seeds self-heal unconditionally; only exact skips (additive mode, same-run resume) |
| `http-retry.ts` | `scripts/lib/http-retry.ts` — transient (5xx/429/network) retries then THROWS; 404/410 returned as positive gone-evidence |
| `seed-writer.ts` | `stampIngestMeta()` — one canonical `_ingest` shape written by the single `ingest()` funnel all acquisition paths share |
| fail-loud exit codes | `scripts/lib/refresh-worklist.ts` + bulk runner — exit 2 on partial failure; gone/failed enumerated in a JSON run report |

Also: bulk runner politeness floor raised 350ms → **2,000ms** (enforced, refuses lower `--delay-ms`); identity-mismatch guard (URL serving a different year/number than it claims is a loud failure, never a silent overwrite); `sources.yml` `rebuild_contract.ingest_cmd` → `npm run ingest:refresh` (`ingest:fetch` is a methodology-MCP template artifact that exits 1 in this repo — no `data/content/`). Repealed seeds carry `Ophævet <date>` (DateOfHistoricMark preferred over EndDate) which `build-db.ts` already parses into the document validity window.

> Overlap note: `feat/2026-06-10-rebuild-contract` (no PR yet) adds the same `rebuild_contract` block with the broken `ingest_cmd: npm run ingest:fetch`. This PR's version is the corrected one; resolve in favor of `ingest:refresh` on conflict.

## Verification

- TDD: 37 new tests in `tests/ingest/` (written failing first). Full suite: **196 passed + 31 contract tests passed** (contract suite ran against a freshly built DB instead of skipping), `tsc --noEmit` clean.
- Live single-doc re-ingest of 2019_241: `in_force` → `repealed`, full `_ingest` stamp, same 258 provisions.
- Live 5-doc bulk run (new 2026 docs): all `fetch_new`, statuses `Valid→in_force`, exit 0, JSON report written.
- Resume semantics live-verified: rerun with `--skip-stamped-since <run1-start>` classifies exactly those 5 as `skip_current` (worklist: `fetch_new=228, refetch_unknown=278, skip_current=5` for the 2026 window).
- Producer→consumer seam: `npm run build:db` over the mixed stamped/unstamped corpus (62,768 docs) completes; repaired seed lands as `repealed`, new seeds as `in_force`.

## What this PR does NOT do

- It does not commit the repaired corpus. The full ~44h acquisition is running detached on the workstation (log: `/tmp/danish-version-repair-20260610.log`, report: `reports/ingest-refresh-2026-06-10-full.json` in the worktree); the post-acquisition build + validation + data commit is a follow-up.
- It does not deploy anything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
